### PR TITLE
Fix out-of-bounds reads when parsing some malformed headers

### DIFF
--- a/gmime/gmime-param.c
+++ b/gmime/gmime-param.c
@@ -903,7 +903,7 @@ decode_quoted_string (const char **in)
 	start = inptr++;
 	
 	while (*inptr && *inptr != '"') {
-		if (*inptr++ == '\\') {
+		if (*inptr++ == '\\' && *inptr) {
 			unescape = TRUE;
 			inptr++;
 		}
@@ -925,7 +925,8 @@ decode_quoted_string (const char **in)
 		while (*inptr) {
 			if (*inptr == '\\')
 				inptr++;
-			*outptr++ = *inptr++;
+			if (*inptr)
+				*outptr++ = *inptr++;
 		}
 		
 		*outptr = '\0';

--- a/gmime/gmime-parse-utils.c
+++ b/gmime/gmime-parse-utils.c
@@ -380,7 +380,8 @@ decode_domain_literal (const char **in, GString *domain)
 				     *inptr, *in));
 			
 			/* try and skip to the next char ?? */
-			inptr++;
+			if (*inptr)
+				inptr++;
 		}
 	}
 	

--- a/gmime/gmime-utils.c
+++ b/gmime/gmime-utils.c
@@ -1526,7 +1526,7 @@ tokenize_rfc2047_phrase (GMimeParserOptions *options, const char *in, size_t *le
 					}
 					
 					/* sanity check encoding type */
-					if (inptr[0] != '?' || !strchr ("BbQq", inptr[1]) || inptr[2] != '?')
+					if (inptr[0] != '?' || inptr[1] == '\0' || !strchr ("BbQq", inptr[1]) || inptr[2] != '?')
 						goto non_rfc2047;
 					
 					inptr += 3;
@@ -1657,7 +1657,7 @@ tokenize_rfc2047_text (GMimeParserOptions *options, const char *in, size_t *len)
 					}
 					
 					/* sanity check encoding type */
-					if (inptr[0] != '?' || !strchr ("BbQq", inptr[1]) || inptr[2] != '?')
+					if (inptr[0] != '?' || inptr[1] == '\0' || !strchr ("BbQq", inptr[1]) || inptr[2] != '?')
 						goto non_rfc2047;
 					
 					inptr += 3;

--- a/gmime/internet-address.c
+++ b/gmime/internet-address.c
@@ -1589,7 +1589,7 @@ domain_literal_parse (GString *str, const char **in)
 	skip_lwsp (&inptr);
 	
 	do {
-		while (is_dtext (*inptr))
+		while (*inptr && is_dtext (*inptr))
 			g_string_append_c (str, *inptr++);
 		
 		skip_lwsp (&inptr);


### PR DESCRIPTION
This fixes multiple bugs that made GMime read past the terminating null byte.

Reproducer:

```
From: <@[0
To: 0@[
Subject: =??
Content-Type: text/plain; charset="\
```

Found using [American Fuzzy Lop](http://lcamtuf.coredump.cx/afl/).