### PR TITLE
Include zentimer.h unconditionally

### DIFF
--- a/tests/test-parser.c
+++ b/tests/test-parser.c
@@ -34,8 +34,8 @@
 
 #if !defined (G_OS_WIN32) || defined (__MINGW32__)
 #define ENABLE_ZENTIMER
-#include "zentimer.h"
 #endif
+#include "zentimer.h"
 
 #define TEST_RAW_HEADER
 #define TEST_PRESERVE_HEADERS


### PR DESCRIPTION
The inclusion of `zentimer.h` is necessary even when `ENABLE_ZENTIMER` is not defined; otherwise the `ZenTimer`*() functions wouldn't be available.