### PR TITLE
Fix off-by-one out-of-bounds read in g_mime_charset_canon_name()

### DIFF
--- a/gmime/gmime-charset.c
+++ b/gmime/gmime-charset.c
@@ -587,7 +587,7 @@ g_mime_charset_canon_name (const char *charset)
 		if (endptr == ptr || *endptr != '\0')
 			return charset;
 		
-		if (iso > G_N_ELEMENTS (iso_charsets))
+		if (iso >= G_N_ELEMENTS (iso_charsets))
 			return charset;
 		
 		return iso_charsets[iso];


### PR DESCRIPTION
Found using [American Fuzzy Lop](http://lcamtuf.coredump.cx/afl/).