### PR TITLE
Certificate information cleanup

### DIFF
--- a/docs/reference/gmime-sections.txt
+++ b/docs/reference/gmime-sections.txt
@@ -1383,6 +1383,7 @@ g_mime_iconv_locale_to_utf8_length
 GMimePubKeyAlgo
 GMimeDigestAlgo
 GMimeTrust
+GMimeValidity
 GMimeCertificate
 g_mime_certificate_new
 g_mime_certificate_get_pubkey_algo

--- a/docs/reference/gmime-sections.txt
+++ b/docs/reference/gmime-sections.txt
@@ -1410,6 +1410,8 @@ g_mime_certificate_get_name
 g_mime_certificate_set_name
 g_mime_certificate_get_user_id
 g_mime_certificate_set_user_id
+g_mime_certificate_get_id_validity
+g_mime_certificate_set_id_validity
 <SUBSECTION>
 GMimeCertificateList
 g_mime_certificate_list_new

--- a/docs/reference/gmime-sections.txt
+++ b/docs/reference/gmime-sections.txt
@@ -1407,6 +1407,8 @@ g_mime_certificate_get_email
 g_mime_certificate_set_email
 g_mime_certificate_get_name
 g_mime_certificate_set_name
+g_mime_certificate_get_user_id
+g_mime_certificate_set_user_id
 <SUBSECTION>
 GMimeCertificateList
 g_mime_certificate_list_new

--- a/gmime/gmime-certificate.c
+++ b/gmime/gmime-certificate.c
@@ -95,6 +95,7 @@ g_mime_certificate_init (GMimeCertificate *cert, GMimeCertificateClass *klass)
 	cert->email = NULL;
 	cert->name = NULL;
 	cert->user_id = NULL;
+	cert->id_validity = GMIME_VALIDITY_UNKNOWN;
 }
 
 static void
@@ -484,6 +485,41 @@ g_mime_certificate_get_user_id (GMimeCertificate *cert)
 	g_return_val_if_fail (GMIME_IS_CERTIFICATE (cert), NULL);
 	
 	return cert->user_id;
+}
+
+
+/**
+ * g_mime_certificate_set_id_validity:
+ * @cert: a #GMimeCertificate
+ * @validity: a #GMimeValidity representing the validity of the certificate's identity information.
+ *
+ * Set the validity associated with the certificate's name, email, and user_id.
+ **/
+void
+g_mime_certificate_set_id_validity (GMimeCertificate *cert, GMimeValidity validity)
+{
+	g_return_if_fail (GMIME_IS_CERTIFICATE (cert));
+	
+	cert->id_validity = validity;
+}
+
+
+/**
+ * g_mime_certificate_get_id_validity:
+ * @cert: a #GMimeCertificate
+ *
+ * Get the validity of the certificate's identity information.  This
+ * validity applies to the name, email, and user_id fields associated
+ * with the certificate.
+ *
+ * Returns: the identity validity of the certificate.
+ **/
+GMimeValidity
+g_mime_certificate_get_id_validity (GMimeCertificate *cert)
+{
+	g_return_val_if_fail (GMIME_IS_CERTIFICATE (cert), GMIME_VALIDITY_UNKNOWN);
+	
+	return cert->id_validity;
 }
 
 

--- a/gmime/gmime-certificate.c
+++ b/gmime/gmime-certificate.c
@@ -94,6 +94,7 @@ g_mime_certificate_init (GMimeCertificate *cert, GMimeCertificateClass *klass)
 	cert->keyid = NULL;
 	cert->email = NULL;
 	cert->name = NULL;
+	cert->user_id = NULL;
 }
 
 static void
@@ -107,6 +108,7 @@ g_mime_certificate_finalize (GObject *object)
 	g_free (cert->keyid);
 	g_free (cert->email);
 	g_free (cert->name);
+	g_free (cert->user_id);
 	
 	G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -428,6 +430,40 @@ g_mime_certificate_get_name (GMimeCertificate *cert)
 	g_return_val_if_fail (GMIME_IS_CERTIFICATE (cert), NULL);
 	
 	return cert->name;
+}
+
+
+/**
+ * g_mime_certificate_set_user_id:
+ * @cert: a #GMimeCertificate
+ * @name: the full User ID for a certificate
+ *
+ * Set the certificate's User ID.
+ **/
+void
+g_mime_certificate_set_user_id (GMimeCertificate *cert, const char *user_id)
+{
+	g_return_if_fail (GMIME_IS_CERTIFICATE (cert));
+	
+	g_free (cert->user_id);
+	cert->user_id = g_strdup (user_id);
+}
+
+
+/**
+ * g_mime_certificate_get_user_id:
+ * @cert: a #GMimeCertificate
+ *
+ * Get the certificate's full User ID.
+ *
+ * Returns: the certificate's User ID or %NULL if unspecified.
+ **/
+const char *
+g_mime_certificate_get_user_id (GMimeCertificate *cert)
+{
+	g_return_val_if_fail (GMIME_IS_CERTIFICATE (cert), NULL);
+	
+	return cert->user_id;
 }
 
 

--- a/gmime/gmime-certificate.c
+++ b/gmime/gmime-certificate.c
@@ -370,7 +370,8 @@ g_mime_certificate_get_key_id (GMimeCertificate *cert)
  * @cert: a #GMimeCertificate
  * @email: certificate's email
  *
- * Set the certificate's email.
+ * Set the email address associated with the
+ * certificate. (e.g. "jane\@example.org")
  **/
 void
 g_mime_certificate_set_email (GMimeCertificate *cert, const char *email)
@@ -386,9 +387,14 @@ g_mime_certificate_set_email (GMimeCertificate *cert, const char *email)
  * g_mime_certificate_get_email:
  * @cert: a #GMimeCertificate
  *
- * Get the certificate's email.
+ * Get the email address associated with the certificate.  If the
+ * certificate contains more than one email address with different
+ * validities, the email address with the highest validity is
+ * returned.  If more than one email address appears in the
+ * certificate with the same (highest) validity, the first such email
+ * address will be returned.
  *
- * Returns: the certificate's email or %NULL if unspecified.
+ * Returns: the relevant e-mail address, or %NULL if unspecified.
  **/
 const char *
 g_mime_certificate_get_email (GMimeCertificate *cert)
@@ -404,7 +410,9 @@ g_mime_certificate_get_email (GMimeCertificate *cert)
  * @cert: a #GMimeCertificate
  * @name: certificate's name
  *
- * Set the certificate's name.
+ * Set the name associated with the certificate.  For email
+ * certificates, this is usually the name of the person who controls
+ * the certificate (encoded in UTF-8). (e.g. "Jane Doe")
  **/
 void
 g_mime_certificate_set_name (GMimeCertificate *cert, const char *name)
@@ -420,9 +428,15 @@ g_mime_certificate_set_name (GMimeCertificate *cert, const char *name)
  * g_mime_certificate_get_name:
  * @cert: a #GMimeCertificate
  *
- * Get the certificate's name.
+ * Get the name associated with the certificate.  For email
+ * certificates, this is usually the name of the person who controls
+ * the certificate (encoded in UTF-8).  If the certificate contains
+ * more than one name with different validities, the name with the
+ * highest validity is returned.  If more than one name appears in the
+ * certificate with the same (highest) validity, the first such name
+ * will be returned.
  *
- * Returns: the certificate's name or %NULL if unspecified.
+ * Returns: the the relevant name or %NULL if unspecified.
  **/
 const char *
 g_mime_certificate_get_name (GMimeCertificate *cert)
@@ -438,7 +452,9 @@ g_mime_certificate_get_name (GMimeCertificate *cert)
  * @cert: a #GMimeCertificate
  * @name: the full User ID for a certificate
  *
- * Set the certificate's User ID.
+ * Set the certificate's full User ID.  By convention, this is usually
+ * a mail name-addr as described in RFC 5322.  (e.g. "Jane Doe
+ * &lt;jane\@example.org&gt;")
  **/
 void
 g_mime_certificate_set_user_id (GMimeCertificate *cert, const char *user_id)
@@ -454,9 +470,13 @@ g_mime_certificate_set_user_id (GMimeCertificate *cert, const char *user_id)
  * g_mime_certificate_get_user_id:
  * @cert: a #GMimeCertificate
  *
- * Get the certificate's full User ID.
+ * Get the certificate's full User ID.  If the certificate contains
+ * more than one User ID with different validities, the User ID with
+ * the highest validity is returned.  If more than one User ID appears
+ * in the certificate with the same (highest) validity, the first such
+ * User ID will be returned.
  *
- * Returns: the certificate's User ID or %NULL if unspecified.
+ * Returns: the relevant User ID or %NULL if unspecified.
  **/
 const char *
 g_mime_certificate_get_user_id (GMimeCertificate *cert)

--- a/gmime/gmime-certificate.h
+++ b/gmime/gmime-certificate.h
@@ -196,6 +196,7 @@ typedef enum {
  * @email: The email address of the person or entity.
  * @name: The name of the person or entity.
  * @user_id: The full User ID of the certificate.
+ * @id_validity: the validity of the email address, name, and User ID.
  *
  * An object containing useful information about a certificate.
  **/
@@ -214,6 +215,7 @@ struct _GMimeCertificate {
 	char *email;
 	char *name;
 	char *user_id;
+	GMimeValidity id_validity;
 };
 
 struct _GMimeCertificateClass {
@@ -255,6 +257,9 @@ const char *g_mime_certificate_get_name (GMimeCertificate *cert);
 
 void g_mime_certificate_set_user_id (GMimeCertificate *cert, const char *user_id);
 const char *g_mime_certificate_get_user_id (GMimeCertificate *cert);
+
+void g_mime_certificate_set_id_validity (GMimeCertificate *cert, GMimeValidity validity);
+GMimeValidity g_mime_certificate_get_id_validity (GMimeCertificate *cert);
 
 void g_mime_certificate_set_created (GMimeCertificate *cert, time_t created);
 time_t g_mime_certificate_get_created (GMimeCertificate *cert);

--- a/gmime/gmime-certificate.h
+++ b/gmime/gmime-certificate.h
@@ -121,14 +121,22 @@ typedef enum {
 
 /**
  * GMimeTrust:
- * @GMIME_TRUST_UNKNOWN: The certificate or key is of unknown validity.
- * @GMIME_TRUST_UNDEFINED: The validity of the certificate or key is undefined.
- * @GMIME_TRUST_NEVER: The certificate or key should never be treated as valid.
- * @GMIME_TRUST_MARGINAL: The certificate or key is marginally valid.
- * @GMIME_TRUST_FULL: The certificate or key is fully valid.
- * @GMIME_TRUST_ULTIMATE: The certificate or key is ultimately valid.
+ * @GMIME_TRUST_UNKNOWN: We do not know whether to rely on identity assertions made by the certificate.
+ * @GMIME_TRUST_UNDEFINED: We do not have enough information to decide whether to rely on identity assertions made by the certificate.
+ * @GMIME_TRUST_NEVER: We should never rely on identity assertions made by the certificate.
+ * @GMIME_TRUST_MARGINAL: We can rely on identity assertions made by this certificate as long as they are corroborated by other marginally-trusted certificates.
+ * @GMIME_TRUST_FULL: We can rely on identity assertions made by this certificate.
+ * @GMIME_TRUST_ULTIMATE: This certificate is an undeniable root of trust (e.g. normally, this is a certificate controlled by the user themselves).
  *
- * The trust level of a certificate or key.
+ * The trust level of a certificate.  Trust level tries to answer the
+ * question: "How much is the user willing to rely on cryptographic
+ * identity assertions made by the owner of this certificate?"
+ * 
+ * By way of comparison with web browser X.509 certificate validation
+ * stacks, the certificate of a "Root CA" has @GMIME_TRUST_ULTIMATE,
+ * while the certificate of an intermediate CA has @GMIME_TRUST_FULL,
+ * and an end-entity certificate (e.g., with CA:FALSE set) would have
+ * @GMIME_TRUST_NEVER.
  **/
 typedef enum {
 	GMIME_TRUST_UNKNOWN   = 0,
@@ -138,6 +146,40 @@ typedef enum {
 	GMIME_TRUST_FULL      = 4,
 	GMIME_TRUST_ULTIMATE  = 5
 } GMimeTrust;
+
+/**
+ * GMimeValidity:
+ * @GMIME_VALIDITY_UNKNOWN: The User ID of the certificate is of unknown validity.
+ * @GMIME_VALIDITY_UNDEFINED: The User ID of the certificate is undefined.
+ * @GMIME_VALIDITY_NEVER: The User ID of the certificate is never to be treated as valid.
+ * @GMIME_VALIDITY_MARGINAL: The User ID of the certificate is marginally valid (e.g. it has been certified by only one marginally-trusted party).
+ * @GMIME_VALIDITY_FULL: The User ID of the certificate is fully valid.
+ * @GMIME_VALIDITY_ULTIMATE: The User ID of the certificate is ultimately valid (i.e., usually the certificate belongs to the local user themselves).
+ *
+ * The validity level of a certificate's User ID.  Validity level
+ * tries to answer the question: "How strongly do we believe that this
+ * certificate belongs to the party it says it belongs to?"
+ *
+ * Note that some OpenPGP certificates have multiple User IDs, and
+ * each User ID may have a different validity level (e.g. depending on
+ * which third parties have certified which User IDs, and which third
+ * parties the local user has chosen to trust).
+ *
+ * Similarly, an X.509 certificate can have multiple SubjectAltNames,
+ * and each name may also have a different validity level (e.g. if the
+ * issuing CA is bound by name constraints).
+ *
+ * Note that the GMime API currently only exposes the highest-validty
+ * User ID for any given certificate.
+ **/
+typedef enum {
+	GMIME_VALIDITY_UNKNOWN   = 0,
+	GMIME_VALIDITY_UNDEFINED = 1,
+	GMIME_VALIDITY_NEVER     = 2,
+	GMIME_VALIDITY_MARGINAL  = 3,
+	GMIME_VALIDITY_FULL      = 4,
+	GMIME_VALIDITY_ULTIMATE  = 5
+} GMimeValidity;
 
 /**
  * GMimeCertificate:

--- a/gmime/gmime-certificate.h
+++ b/gmime/gmime-certificate.h
@@ -153,6 +153,7 @@ typedef enum {
  * @keyid: The certificate's key id.
  * @email: The email address of the person or entity.
  * @name: The name of the person or entity.
+ * @user_id: The full User ID of the certificate.
  *
  * An object containing useful information about a certificate.
  **/
@@ -170,6 +171,7 @@ struct _GMimeCertificate {
 	char *keyid;
 	char *email;
 	char *name;
+	char *user_id;
 };
 
 struct _GMimeCertificateClass {
@@ -208,6 +210,9 @@ const char *g_mime_certificate_get_email (GMimeCertificate *cert);
 
 void g_mime_certificate_set_name (GMimeCertificate *cert, const char *name);
 const char *g_mime_certificate_get_name (GMimeCertificate *cert);
+
+void g_mime_certificate_set_user_id (GMimeCertificate *cert, const char *user_id);
+const char *g_mime_certificate_get_user_id (GMimeCertificate *cert);
 
 void g_mime_certificate_set_created (GMimeCertificate *cert, time_t created);
 time_t g_mime_certificate_get_created (GMimeCertificate *cert);

--- a/gmime/gmime-gpgme-utils.c
+++ b/gmime/gmime-gpgme-utils.c
@@ -366,6 +366,7 @@ g_mime_gpgme_get_signatures (gpgme_ctx_t ctx, gboolean verify)
 				}
 				uid = uid->next;
 			}
+			g_mime_certificate_set_id_validity (signature->cert, (GMimeValidity)(validity));
 			
 			/* get the subkey used for signing */
 			subkey = key->subkeys;

--- a/gmime/gmime-gpgme-utils.c
+++ b/gmime/gmime-gpgme-utils.c
@@ -290,6 +290,7 @@ g_mime_gpgme_get_signatures (gpgme_ctx_t ctx, gboolean verify)
 		g_mime_certificate_set_pubkey_algo (signature->cert, (GMimePubKeyAlgo) sig->pubkey_algo);
 		g_mime_certificate_set_digest_algo (signature->cert, (GMimeDigestAlgo) sig->hash_algo);
 		g_mime_certificate_set_fingerprint (signature->cert, sig->fpr);
+		g_mime_certificate_set_key_id (signature->cert, sig->fpr);
 		
 		if (gpgme_get_key (ctx, sig->fpr, &key, 0) == GPG_ERR_NO_ERROR && key) {
 			/* get more signer info from their signing key */
@@ -297,7 +298,7 @@ g_mime_gpgme_get_signatures (gpgme_ctx_t ctx, gboolean verify)
 			g_mime_certificate_set_issuer_serial (signature->cert, key->issuer_serial);
 			g_mime_certificate_set_issuer_name (signature->cert, key->issuer_name);
 			
-			/* get the keyid, name, and email address */
+			/* get the name and email address */
 			uid = key->uids;
 			while (uid) {
 				if (uid->name && *uid->name)
@@ -306,10 +307,7 @@ g_mime_gpgme_get_signatures (gpgme_ctx_t ctx, gboolean verify)
 				if (uid->email && *uid->email)
 					g_mime_certificate_set_email (signature->cert, uid->email);
 				
-				if (uid->uid && *uid->uid)
-					g_mime_certificate_set_key_id (signature->cert, uid->uid);
-				
-				if (signature->cert->name && signature->cert->email && signature->cert->keyid)
+				if (signature->cert->name && signature->cert->email)
 					break;
 				
 				uid = uid->next;

--- a/gmime/gmime-gpgme-utils.c
+++ b/gmime/gmime-gpgme-utils.c
@@ -298,7 +298,7 @@ g_mime_gpgme_get_signatures (gpgme_ctx_t ctx, gboolean verify)
 			g_mime_certificate_set_issuer_serial (signature->cert, key->issuer_serial);
 			g_mime_certificate_set_issuer_name (signature->cert, key->issuer_name);
 			
-			/* get the name and email address */
+			/* get the name, email address, and full user id */
 			uid = key->uids;
 			while (uid) {
 				if (uid->name && *uid->name)
@@ -307,7 +307,10 @@ g_mime_gpgme_get_signatures (gpgme_ctx_t ctx, gboolean verify)
 				if (uid->email && *uid->email)
 					g_mime_certificate_set_email (signature->cert, uid->email);
 				
-				if (signature->cert->name && signature->cert->email)
+				if (uid->uid && *uid->uid)
+					g_mime_certificate_set_user_id (signature->cert, uid->uid);
+				
+				if (signature->cert->name && signature->cert->email && signature->cert->user_id)
 					break;
 				
 				uid = uid->next;

--- a/tests/test-pgpmime.c
+++ b/tests/test-pgpmime.c
@@ -721,28 +721,28 @@ int main (int argc, char *argv[])
 	
 	g_free (session_key);
 	
-	testsuite_check ("rfc2440 sign");
+	testsuite_check ("rfc4880 sign");
 	try {
 		test_openpgp_sign ();
 		testsuite_check_passed ();
 	} catch (ex) {
-		testsuite_check_failed ("rfc2440 sign failed: %s", ex->message);
+		testsuite_check_failed ("rfc4880 sign failed: %s", ex->message);
 	} finally;
 	
-	testsuite_check ("rfc2440 encrypt");
+	testsuite_check ("rfc4880 encrypt");
 	try {
 		test_openpgp_encrypt (FALSE);
 		testsuite_check_passed ();
 	} catch (ex) {
-		testsuite_check_failed ("rfc2440 encrypt failed: %s", ex->message);
+		testsuite_check_failed ("rfc4880 encrypt failed: %s", ex->message);
 	} finally;
 	
-	testsuite_check ("rfc2440 sign+encrypt");
+	testsuite_check ("rfc4880 sign+encrypt");
 	try {
 		test_openpgp_encrypt (TRUE);
 		testsuite_check_passed ();
 	} catch (ex) {
-		testsuite_check_failed ("rfc2440 sign+encrypt failed: %s", ex->message);
+		testsuite_check_failed ("rfc4880 sign+encrypt failed: %s", ex->message);
 	} finally;
 	
 	g_object_unref (ctx);

--- a/tests/test-pgpmime.c
+++ b/tests/test-pgpmime.c
@@ -92,6 +92,7 @@ print_verify_results (GMimeSignatureList *signatures)
 		
 		fprintf (stdout, "\tName: %s\n", sig->cert->name ? sig->cert->name : "(null)");
 		fprintf (stdout, "\tKeyId: %s\n", sig->cert->keyid ? sig->cert->keyid : "(null)");
+		fprintf (stdout, "\tUserID: %s\n", sig->cert->user_id ? sig->cert->user_id : "(null)");
 		fprintf (stdout, "\tFingerprint: %s\n", sig->cert->fingerprint ? sig->cert->fingerprint : "(null)");
 		fprintf (stdout, "\tTrust: ");
 		

--- a/tests/test-smime.c
+++ b/tests/test-smime.c
@@ -94,6 +94,7 @@ print_verify_results (GMimeSignatureList *signatures)
 		
 		fprintf (stdout, "\tName: %s\n", sig->cert->name ? sig->cert->name : "(null)");
 		fprintf (stdout, "\tKeyId: %s\n", sig->cert->keyid ? sig->cert->keyid : "(null)");
+		fprintf (stdout, "\tUserID: %s\n", sig->cert->user_id ? sig->cert->user_id : "(null)");
 		fprintf (stdout, "\tFingerprint: %s\n", sig->cert->fingerprint ? sig->cert->fingerprint : "(null)");
 		fprintf (stdout, "\tTrust: ");
 		


### PR DESCRIPTION
After reviewing certificate handling for signatures in `notmuch` when built against GMime 3.0, i determined that GMime hasn't been exposing enough information for an MUA to present a reasonable perspective on a signed message.  In particular, GMimeCertificate:

 * GMimeCertificate's `key_id` member contained different information depending on whether the certificate was accessed as part of a signature verification or an encryption target.  This was solved by making `key_id` uniformly mean an identifier for the key, and adding an distinct `user_id` member to the object.
 * GMimeCertificate was presenting the first pieces of identity information it found in the certificate (`name` and `email`), even though some certificates contain more identity information, and some of it is better (more "valid") than others.  GMime should now prefer the more-valid identity information.
 * GMimeCertificate was not exposing the calculated validity of its exposed identity information, which makes it difficult for a mail client to know what to display to the user.  GMime now exposes the validity level of the identity information it reports.

The series ends up extending the GMime API slightly, and expands the size of the GMimeCertificate object.  This means that users who depend on the standard API (constructors, destructors, accessor functions) will be fine, but users who do explicit stack-based allocation, or who use fixed-size `malloc()`,  or who directly fiddle with internal structure members might have trouble.

My understanding is that this is considered an acceptable API extension (not an ABI break), as it mirrors a similar situation in the 2.6 branch on session key retrieval last year.  Hopefully this can be treated the same way on the 3.0 branch, since the functionality added in this series is really useful for making `notmuch` a better mail client! 