### PR TITLE
Enable warnings if building from git, and fix a number of them

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -618,6 +618,11 @@ if test "x$LIBIDN_LIBS" != "x"; then
 fi
 
 CFLAGS="$CFLAGS -fno-strict-aliasing"
+# enable more warnings when building from Git (assume we use gcc/clang)
+# add -Werror to make them fatal (so they get fixed, actually...)
+if test -d "${srcdir}/.git"; then
+	CFLAGS="$CFLAGS -Wall -Wshadow -Wunreachable-code -Wformat=2"
+fi
 LIBS="$LIBS $EXTRA_LIBS"
 
 AC_SUBST(CFLAGS)

--- a/gmime/gmime-application-pkcs7-mime.c
+++ b/gmime/gmime-application-pkcs7-mime.c
@@ -170,6 +170,7 @@ g_mime_application_pkcs7_mime_new (GMimeSecureMimeType type)
 		name = "smime.p7c";
 		break;
 	default:
+		g_assert_not_reached();
 		break;
 	}
 	
@@ -233,11 +234,9 @@ g_mime_application_pkcs7_mime_encrypt (GMimeObject *entity, GMimeEncryptFlags fl
 {
 	GMimeApplicationPkcs7Mime *pkcs7_mime;
 	GMimeStream *ciphertext, *stream;
-	GMimeContentType *content_type;
 	GMimeFormatOptions *options;
 	GMimeDataWrapper *content;
 	GMimeCryptoContext *ctx;
-	GMimeFilter *filter;
 	
 	g_return_val_if_fail (GMIME_IS_OBJECT (entity), NULL);
 	g_return_val_if_fail (recipients != NULL, NULL);
@@ -404,11 +403,9 @@ g_mime_application_pkcs7_mime_sign (GMimeObject *entity, const char *userid, GEr
 {
 	GMimeApplicationPkcs7Mime *pkcs7_mime;
 	GMimeStream *ciphertext, *stream;
-	GMimeContentType *content_type;
 	GMimeFormatOptions *options;
 	GMimeDataWrapper *content;
 	GMimeCryptoContext *ctx;
-	GMimeFilter *filter;
 	
 	g_return_val_if_fail (GMIME_IS_OBJECT (entity), NULL);
 	g_return_val_if_fail (userid != NULL, NULL);

--- a/gmime/gmime-autocrypt.c
+++ b/gmime/gmime-autocrypt.c
@@ -214,7 +214,7 @@ g_mime_autocrypt_header_new_from_string (const char *string)
 	kjoined = g_strjoinv ("", ksplit);
 	gsize decodedlen = 0;
 	g_base64_decode_inplace (kjoined, &decodedlen);
-	newkeydata = g_byte_array_new_take (kjoined, decodedlen);
+	newkeydata = g_byte_array_new_take ((guint8 *) kjoined, decodedlen);
 	kjoined = NULL;
 	g_mime_autocrypt_header_set_keydata (ret, newkeydata);
 	
@@ -780,6 +780,8 @@ g_mime_autocrypt_header_list_get_header_at (GMimeAutocryptHeaderList *acheaders,
 
 	if (n < acheaders->array->len)
 		return (GMimeAutocryptHeader*)(acheaders->array->pdata[n]);
+	else
+		return NULL;
 }
 
 /**

--- a/gmime/gmime-filter-dos2unix.c
+++ b/gmime/gmime-filter-dos2unix.c
@@ -37,7 +37,6 @@
 
 static void g_mime_filter_dos2unix_class_init (GMimeFilterDos2UnixClass *klass);
 static void g_mime_filter_dos2unix_init (GMimeFilterDos2Unix *filter, GMimeFilterDos2UnixClass *klass);
-static void g_mime_filter_dos2unix_finalize (GObject *object);
 
 static GMimeFilter *filter_copy (GMimeFilter *filter);
 static void filter_filter (GMimeFilter *filter, char *in, size_t len, size_t prespace,

--- a/gmime/gmime-filter-enriched.c
+++ b/gmime/gmime-filter-enriched.c
@@ -144,7 +144,6 @@ g_mime_filter_enriched_class_init (GMimeFilterEnrichedClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	GMimeFilterClass *filter_class = GMIME_FILTER_CLASS (klass);
-	guint i;
 	
 	parent_class = g_type_class_ref (GMIME_TYPE_FILTER);
 	
@@ -191,12 +190,6 @@ enriched_tag_needs_param (const char *tag)
 	return FALSE;
 }
 #endif
-
-static gboolean
-html_tag_needs_param (const char *tag)
-{
-	return strstr (tag, "%s") != NULL;
-}
 
 static const char *valid_colours[] = {
 	"red", "green", "blue", "yellow", "cyan", "magenta", "black", "white"

--- a/gmime/gmime-filter-gzip.c
+++ b/gmime/gmime-filter-gzip.c
@@ -259,12 +259,12 @@ gzip_filter (GMimeFilter *filter, char *in, size_t len, size_t prespace,
 			w(fprintf (stderr, "gzip: %d: %s\n", retval, priv->stream->msg));
 		
 		if (flush == Z_FULL_FLUSH) {
-			size_t outlen;
+			size_t olen;
 			
-			outlen = filter->outsize - priv->stream->avail_out;
-			g_mime_filter_set_size (filter, outlen + (priv->stream->avail_in * 2) + 12, TRUE);
-			priv->stream->next_out = (unsigned char *) filter->outbuf + outlen;
-			priv->stream->avail_out = filter->outsize - outlen;
+			olen = filter->outsize - priv->stream->avail_out;
+			g_mime_filter_set_size (filter, olen + (priv->stream->avail_in * 2) + 12, TRUE);
+			priv->stream->next_out = (unsigned char *) filter->outbuf + olen;
+			priv->stream->avail_out = filter->outsize - olen;
 			
 			if (priv->stream->avail_in == 0) {
 				guint32 val;
@@ -415,17 +415,17 @@ gunzip_filter (GMimeFilter *filter, char *in, size_t len, size_t prespace,
 			w(fprintf (stderr, "gunzip: %d: %s\n", retval, priv->stream->msg));
 		
 		if (flush == Z_FULL_FLUSH) {
-			size_t outlen;
+			size_t olen;
 			
 			if (priv->stream->avail_in == 0) {
 				/* FIXME: extract & compare calculated crc32 and isize values? */
 				break;
 			}
 			
-			outlen = filter->outsize - priv->stream->avail_out;
-			g_mime_filter_set_size (filter, outlen + (priv->stream->avail_in * 2) + 12, TRUE);
-			priv->stream->next_out = (unsigned char *) filter->outbuf + outlen;
-			priv->stream->avail_out = filter->outsize - outlen;
+			olen = filter->outsize - priv->stream->avail_out;
+			g_mime_filter_set_size (filter, olen + (priv->stream->avail_in * 2) + 12, TRUE);
+			priv->stream->next_out = (unsigned char *) filter->outbuf + olen;
+			priv->stream->avail_out = filter->outsize - olen;
 		} else {
 			priv->stream->avail_in += 8;
 			

--- a/gmime/gmime-filter-smtp-data.c
+++ b/gmime/gmime-filter-smtp-data.c
@@ -37,7 +37,6 @@
 
 static void g_mime_filter_smtp_data_class_init (GMimeFilterSmtpDataClass *klass);
 static void g_mime_filter_smtp_data_init (GMimeFilterSmtpData *filter, GMimeFilterSmtpDataClass *klass);
-static void g_mime_filter_smtp_data_finalize (GObject *object);
 
 static GMimeFilter *filter_copy (GMimeFilter *filter);
 static void filter_filter (GMimeFilter *filter, char *in, size_t len, size_t prespace,
@@ -96,8 +95,6 @@ g_mime_filter_smtp_data_init (GMimeFilterSmtpData *filter, GMimeFilterSmtpDataCl
 static GMimeFilter *
 filter_copy (GMimeFilter *filter)
 {
-	GMimeFilterSmtpData *smtp_data = (GMimeFilterSmtpData *) filter;
-	
 	return g_mime_filter_smtp_data_new ();
 }
 

--- a/gmime/gmime-filter-unix2dos.c
+++ b/gmime/gmime-filter-unix2dos.c
@@ -37,7 +37,6 @@
 
 static void g_mime_filter_unix2dos_class_init (GMimeFilterUnix2DosClass *klass);
 static void g_mime_filter_unix2dos_init (GMimeFilterUnix2Dos *filter, GMimeFilterUnix2DosClass *klass);
-static void g_mime_filter_unix2dos_finalize (GObject *object);
 
 static GMimeFilter *filter_copy (GMimeFilter *filter);
 static void filter_filter (GMimeFilter *filter, char *in, size_t len, size_t prespace,

--- a/gmime/gmime-gpgme-utils.c
+++ b/gmime/gmime-gpgme-utils.c
@@ -573,8 +573,6 @@ GMimeDecryptResult *
 g_mime_gpgme_decrypt (gpgme_ctx_t ctx, GMimeDecryptFlags flags, const char *session_key,
 		      GMimeStream *istream, GMimeStream *ostream, GError **err)
 {
-	GMimeDecryptResult *result;
-	gpgme_decrypt_result_t res;
 	gpgme_data_t input, output;
 	gpgme_error_t error;
 	
@@ -657,7 +655,6 @@ g_mime_gpgme_export (gpgme_ctx_t ctx, const char *keys[], GMimeStream *ostream, 
 {
 	gpgme_data_t keydata;
 	gpgme_error_t error;
-	guint i;
 	
 	if ((error = gpgme_data_new_from_cbs (&keydata, &gpg_stream_funcs, ostream)) != GPG_ERR_NO_ERROR) {
 		g_set_error (err, GMIME_GPGME_ERROR, error, _("Could not open output stream: %s"),

--- a/gmime/gmime-header.c
+++ b/gmime/gmime-header.c
@@ -1265,8 +1265,6 @@ g_mime_header_list_append (GMimeHeaderList *headers, const char *name, const cha
 GMimeHeader *
 g_mime_header_list_get_header (GMimeHeaderList *headers, const char *name)
 {
-	GMimeHeader *header;
-	
 	g_return_val_if_fail (GMIME_IS_HEADER_LIST (headers), NULL);
 	g_return_val_if_fail (name != NULL, NULL);
 	

--- a/gmime/gmime-message.c
+++ b/gmime/gmime-message.c
@@ -36,7 +36,6 @@
 #include "gmime-common.h"
 #include "gmime-stream-mem.h"
 #include "gmime-stream-filter.h"
-#include "gmime-table-private.h"
 #include "gmime-parse-utils.h"
 #include "gmime-internal.h"
 #include "gmime-events.h"
@@ -190,7 +189,6 @@ unblock_changed_event (GMimeMessage *message, GMimeAddressType type)
 static void
 g_mime_message_init (GMimeMessage *message, GMimeMessageClass *klass)
 {
-	GMimeHeaderList *headers = ((GMimeObject *) message)->headers;
 	guint i;
 	
 	message->addrlists = g_new (InternetAddressList *, N_ADDRESS_TYPES);
@@ -379,8 +377,6 @@ message_header_removed (GMimeObject *object, GMimeHeader *header)
 	GMimeParserOptions *options = _g_mime_header_list_get_options (object->headers);
 	GMimeMessage *message = (GMimeMessage *) object;
 	const char *name;
-	time_t date;
-	int offset;
 	guint i;
 	
 	name = g_mime_header_get_name (header);

--- a/gmime/gmime-multipart-encrypted.c
+++ b/gmime/gmime-multipart-encrypted.c
@@ -166,7 +166,6 @@ g_mime_multipart_encrypted_encrypt (GMimeCryptoContext *ctx, GMimeObject *entity
 	GMimeFormatOptions *options;
 	GMimeDataWrapper *content;
 	const char *protocol;
-	GMimeFilter *filter;
 	
 	g_return_val_if_fail (GMIME_IS_CRYPTO_CONTEXT (ctx), NULL);
 	g_return_val_if_fail (GMIME_IS_OBJECT (entity), NULL);

--- a/gmime/gmime-multipart-signed.c
+++ b/gmime/gmime-multipart-signed.c
@@ -377,8 +377,6 @@ g_mime_multipart_signed_verify (GMimeMultipartSigned *mps, GMimeVerifyFlags flag
 	GMimeFormatOptions *options;
 	GMimeDataWrapper *wrapper;
 	GMimeCryptoContext *ctx;
-	GMimeDigestAlgo digest;
-	GMimeFilter *filter;
 	char *mime_type;
 	
 	g_return_val_if_fail (GMIME_IS_MULTIPART_SIGNED (mps), NULL);

--- a/gmime/gmime-object.c
+++ b/gmime/gmime-object.c
@@ -26,7 +26,6 @@
 #include <ctype.h>
 #include <string.h>
 
-#include "gmime-table-private.h"
 #include "gmime-common.h"
 #include "gmime-object.h"
 #include "gmime-stream-mem.h"

--- a/gmime/gmime-param.c
+++ b/gmime/gmime-param.c
@@ -794,7 +794,7 @@ g_mime_param_list_encode (GMimeParamList *list, GMimeFormatOptions *options, gbo
 			/* we need to do special rfc2184 parameter wrapping */
 			size_t maxlen = GMIME_FOLD_LEN - (nlen + 6);
 			char *inend;
-			int i = 0;
+			int cnt = 0;
 			
 			inptr = value;
 			inend = value + vlen;
@@ -816,7 +816,7 @@ g_mime_param_list_encode (GMimeParamList *list, GMimeFormatOptions *options, gbo
 						ptr = q;
 				}
 				
-				if (i != 0) {
+				if (cnt != 0) {
 					g_string_append_c (str, ';');
 					
 					if (fold) {
@@ -830,7 +830,7 @@ g_mime_param_list_encode (GMimeParamList *list, GMimeFormatOptions *options, gbo
 					used = 1;
 				}
 				
-				g_string_append_printf (str, "%s*%d*=", param->name, i++);
+				g_string_append_printf (str, "%s*%d*=", param->name, cnt++);
 				g_string_append_len (str, inptr, (size_t) (ptr - inptr));
 				used += (str->len - here);
 				

--- a/gmime/gmime-parser.c
+++ b/gmime/gmime-parser.c
@@ -873,7 +873,7 @@ static void
 header_parse (GMimeParser *parser)
 {
 	struct _GMimeParserPrivate *priv = parser->priv;
-	gboolean valid = TRUE, blank = FALSE;
+	gboolean blank = FALSE;
 	register char *inptr;
 	Header *header;
 	
@@ -887,7 +887,6 @@ header_parse (GMimeParser *parser)
 		if (is_blank (*inptr)) {
 			blank = TRUE;
 		} else if (blank || is_ctrl (*inptr)) {
-			valid = FALSE;
 			break;
 		}
 		
@@ -1392,11 +1391,11 @@ check_boundary (struct _GMimeParserPrivate *priv, const char *start, size_t len)
 		
 		/* check for OpenPGP markers... */
 		for (i = 0; i < G_N_ELEMENTS (openpgp_markers); i++) {
-			const char *marker = openpgp_markers[i].marker + 2;
+			const char *this_marker = openpgp_markers[i].marker + 2;
 			openpgp_state_t state = openpgp_markers[i].before;
 			size_t n = openpgp_markers[i].len - 2;
 			
-			if (len == n && priv->openpgp == state && !strncmp (marker, start, len))
+			if (len == n && priv->openpgp == state && !strncmp (this_marker, start, len))
 				priv->openpgp = openpgp_markers[i].after;
 		}
 	}
@@ -1573,6 +1572,7 @@ parser_scan_mime_part_content (GMimeParser *parser, GMimePart *mime_part, Bounda
 		start = parser_offset (priv, NULL);
 	} else {
 		stream = g_mime_stream_mem_new ();
+		start = len = 0;	/* values are unused, make compiler happy */
 	}
 	
 	*found = parser_scan_content (parser, stream, &empty);
@@ -1608,7 +1608,6 @@ parser_scan_message_part (GMimeParser *parser, GMimeParserOptions *options, GMim
 	ContentType *content_type;
 	GMimeMessage *message;
 	GMimeObject *object;
-	GMimeStream *stream;
 	Header *header;
 	guint i;
 	
@@ -1844,7 +1843,6 @@ parser_construct_multipart (GMimeParser *parser, GMimeParserOptions *options, Co
 	GMimeMultipart *multipart;
 	const char *boundary;
 	GMimeObject *object;
-	GMimeStream *stream;
 	Header *header;
 	guint i;
 	
@@ -1960,7 +1958,6 @@ parser_construct_message (GMimeParser *parser, GMimeParserOptions *options)
 	ContentType *content_type;
 	GMimeMessage *message;
 	GMimeObject *object;
-	GMimeStream *stream;
 	BoundaryType found;
 	const char *inptr;
 	Header *header;

--- a/gmime/gmime-references.c
+++ b/gmime/gmime-references.c
@@ -23,7 +23,6 @@
 #include <config.h>
 #endif
 
-#include "gmime-table-private.h"
 #include "gmime-parse-utils.h"
 #include "gmime-references.h"
 

--- a/gmime/gmime-stream-buffer.c
+++ b/gmime/gmime-stream-buffer.c
@@ -142,7 +142,6 @@ static ssize_t
 stream_read (GMimeStream *stream, char *buf, size_t len)
 {
 	GMimeStreamBuffer *buffer = (GMimeStreamBuffer *) stream;
-	size_t buflen, offset;
 	ssize_t n, nread = 0;
 	
 	if (buffer->source == NULL) {

--- a/gmime/gmime-utils.c
+++ b/gmime/gmime-utils.c
@@ -289,7 +289,7 @@ static int
 decode_int (const char *in, size_t inlen)
 {
 	register const char *inptr;
-	int sign = 1, val = 0;
+	int val = 0;
 	const char *inend;
 	
 	inptr = in;
@@ -450,7 +450,6 @@ get_tzone (date_token **token)
 {
 	const char *inptr, *inend;
 	char tzone[8];
-	GTimeZone *tz;
 	size_t len, n;
 	int value, i;
 	guint t;
@@ -499,19 +498,18 @@ get_tzone (date_token **token)
 static GDateTime *
 parse_rfc822_date (date_token *tokens)
 {
-	int wday, year, month, day, hour, min, sec, n;
+	int year, month, day, hour, min, sec, n;
 	GTimeZone *tz = NULL;
 	date_token *token;
 	GDateTime *date;
 	
 	token = tokens;
 	
-	wday = year = month = day = hour = min = sec = 0;
+	year = month = day = hour = min = sec = 0;
 	
 	if ((n = get_wday (token->start, token->len)) != -1) {
 		/* not all dates may have this... */
 		token = token->next;
-		wday = n;
 	}
 	
 	/* get the mday */
@@ -573,13 +571,13 @@ parse_rfc822_date (date_token *tokens)
 static GDateTime *
 parse_broken_date (date_token *tokens)
 {
-	int wday, year, month, day, hour, min, sec, n;
+	int year, month, day, hour, min, sec, n;
 	GTimeZone *tz = NULL;
 	date_token *token;
 	GDateTime *date;
 	int mask;
 	
-	wday = year = month = day = hour = min = sec = 0;
+	year = month = day = hour = min = sec = 0;
 	mask = 0;
 	
 	token = tokens;
@@ -588,7 +586,6 @@ parse_broken_date (date_token *tokens)
 			if ((n = get_wday (token->start, token->len)) != -1) {
 				d(printf ("weekday; "));
 				mask |= WEEKDAY;
-				wday = n;
 				goto next;
 			}
 		}
@@ -770,7 +767,6 @@ g_mime_utils_header_decode_date (const char *str)
 char *
 g_mime_utils_generate_message_id (const char *fqdn)
 {
-	static unsigned long int count = 0;
 	const char *hostname = NULL;
 	unsigned char block[8];
 	unsigned long value;
@@ -2329,7 +2325,6 @@ rfc2047_encode (GMimeFormatOptions *options, const char *in, gushort safemask, c
 	GString *out;
 	char *outstr;
 	size_t len;
-	int i = 0;
 	
 	if (!(words = rfc2047_encode_get_rfc822_words (in, safemask & IS_PSAFE)))
 		return g_strdup (in);

--- a/gmime/internet-address.c
+++ b/gmime/internet-address.c
@@ -1399,7 +1399,6 @@ typedef enum {
 static gboolean
 decode_route (const char **in)
 {
-	const char *start = *in;
 	const char *inptr = *in;
 	GString *route;
 	
@@ -1454,7 +1453,6 @@ static gboolean
 localpart_parse (GString *localpart, const char **in)
 {
 	const char *inptr = *in;
-	const char *start = *in;
 	const char *word;
 	
 	do {
@@ -1500,7 +1498,6 @@ dotatom_parse (GString *str, const char **in, const char *sentinels)
 {
 	const char *atom, *comment;
 	const char *inptr = *in;
-	const char *start = *in;
 	GString *domain = str;
 	
 	do {
@@ -1628,9 +1625,7 @@ static gboolean
 addrspec_parse (const char **in, const char *sentinels, char **addrspec, int *at)
 {
 	const char *inptr = *in;
-	const char *start = *in;
 	GString *str;
-	guint domain;
 	
 	str = g_string_new ("");
 	
@@ -1886,7 +1881,6 @@ address_parse (GMimeParserOptions *options, AddressParserFlags flags, const char
 		
 		if (*inptr == '(') {
 			const char *comment = inptr;
-			char *buf;
 			
 			if (!skip_comment (&inptr))
 				goto error;
@@ -1963,7 +1957,6 @@ address_parse (GMimeParserOptions *options, AddressParserFlags flags, const char
 		
 		if (*inptr == '(') {
 			const char *comment = inptr;
-			char *buf;
 			
 			if (!skip_comment (&inptr))
 				goto error;


### PR DESCRIPTION
- configure.ac: enable warnings
- gmime/gmime-application-pkcs7-mime.c:
  g_mime_application_pkcs7_mime_new(): assert() if a weird type has been requested
- gmime/gmime-autocrypt.c:
  g_mime_autocrypt_header_new_from_string(): fix pointer signedness mismatch
  g_mime_autocrypt_header_list_get_header_at(): ensure proper return value
- gmime/gmime-filter-dos2unix.c:
  remove unused function g_mime_filter_dos2unix_finalize()
- gmime/gmime-filter-enriched.c:
  g_mime_filter_enriched_class_init(): remove unused variable
  remove unused function html_tag_needs_param()
- gmime/gmime-filter-gzip.c:
  gzip_filter() and gunzip_filter(): rename local variable which shadows a function parameter
- gmime/gmime-filter-smtp-data.c:
  remove unused function g_mime_filter_smtp_data_finalize()
  filter_copy(): remove unused variable
- gmime/gmime-filter-unix2dos.c:
  remove unused function g_mime_filter_unix2dos_finalize()
- gmime/gmime-gpgme-utils.c:
  g_mime_gpgme_decrypt(), g_mime_gpgme_export(): remove unused variables
- gmime/gmime-header.c:
  g_mime_header_list_get_header(): remove unused variable
- gmime/gmime-message.c:
  remove unused include causing a warning
  g_mime_message_init(), message_header_removed(): remove unused variables
- gmime/gmime-multipart-encrypted.c:
  g_mime_multipart_encrypted_encrypt(): remove unused variable
- gmime/gmime-multipart-signed.c:
  g_mime_multipart_signed_verify(): remove unused variables
- gmime/gmime-object.c:
  remove unused include causing a warning
- gmime/gmime-param.c:
  g_mime_param_list_encode(): rename local variable which shadows a variable from an outer block
- gmime/gmime-parser.c:
  header_parse(): remove unused variable
  check_boundary(): rename local variable which shadows a variable from an outer block
  parser_scan_mime_part_content(): initialise variable
  parser_scan_message_part(), parser_construct_multipart(), parser_construct_message(): remove unused variables
- gmime/gmime-references.c:
  remove unused include causing a warning
- gmime/gmime-stream-buffer.c:
  stream_read(): remove unused variables
- gmime/gmime-utils.c:
  decode_int(), get_tzone(), parse_rfc822_date(), parse_broken_date(), g_mime_utils_generate_message_id(), rfc2047_encode(): remove unused variables
- gmime/internet-address.c:
  decode_route(), localpart_parse(), dotatom_parse(), addrspec_parse(), address_parse(): remove unused variables