### PR TITLE
Base64 decoder multiple chunk bug fix: use GLib Base64 functions

### DIFF
--- a/gmime/gmime-encodings.c
+++ b/gmime/gmime-encodings.c
@@ -54,27 +54,6 @@
 #define GMIME_UUENCODE_CHAR(c) ((c) ? (c) + ' ' : '`')
 #define	GMIME_UUDECODE_CHAR(c) (((c) - ' ') & 077)
 
-static char base64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-static unsigned char gmime_base64_rank[256] = {
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255, 62,255,255,255, 63,
-	 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,255,255,255,  0,255,255,
-	255,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-	 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,255,255,255,255,255,
-	255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-	 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-};
-
 static unsigned char gmime_uu_rank[256] = {
 	 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
 	 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
@@ -371,35 +350,20 @@ g_mime_encoding_flush (GMimeEncoding *state, const char *inbuf, size_t inlen, ch
 size_t
 g_mime_encoding_base64_encode_close (const unsigned char *inbuf, size_t inlen, unsigned char *outbuf, int *state, guint32 *save)
 {
-	unsigned char *outptr = outbuf;
-	int c1, c2;
-	
-	if (inlen > 0)
-		outptr += g_mime_encoding_base64_encode_step (inbuf, inlen, outptr, state, save);
-	
-	c1 = ((unsigned char *)save)[1];
-	c2 = ((unsigned char *)save)[2];
-	
-	switch (((unsigned char *)save)[0]) {
-	case 2:
-		outptr[2] = base64_alphabet [(c2 & 0x0f) << 2];
-		goto skip;
-	case 1:
-		outptr[2] = '=';
-	skip:
-		outptr[0] = base64_alphabet [c1 >> 2];
-		outptr[1] = base64_alphabet [c2 >> 4 | ((c1 & 0x3) << 4)];
-		outptr[3] = '=';
-		outptr += 4;
-		break;
+	gint glib_save;
+	gsize glib_res;
+
+	glib_save = *save;
+	if (inlen > 0U) {
+		glib_res = g_base64_encode_step ((const guchar *) inbuf, inlen, TRUE, (gchar *) outbuf, state, &glib_save);
+		outbuf = &outbuf[glib_res];
+	} else {
+		glib_res = 0U;
 	}
-	
-	*outptr++ = '\n';
-	
-	*save = 0;
-	*state = 0;
-	
-	return (outptr - outbuf);
+	glib_res += g_base64_encode_close (TRUE, (gchar *) outbuf, state, &glib_save);
+	*save = glib_save;
+
+	return glib_res;
 }
 
 
@@ -421,73 +385,14 @@ g_mime_encoding_base64_encode_close (const unsigned char *inbuf, size_t inlen, u
 size_t
 g_mime_encoding_base64_encode_step (const unsigned char *inbuf, size_t inlen, unsigned char *outbuf, int *state, guint32 *save)
 {
-	register const unsigned char *inptr;
-	register unsigned char *outptr;
-	
-	if (inlen == 0)
-		return 0;
-	
-	outptr = outbuf;
-	inptr = inbuf;
-	
-	if (inlen + ((unsigned char *)save)[0] > 2) {
-		const unsigned char *inend = inbuf + inlen - 2;
-		register int c1 = 0, c2 = 0, c3 = 0;
-		register int already;
-		
-		already = *state;
-		
-		switch (((char *)save)[0]) {
-		case 1:	c1 = ((unsigned char *)save)[1]; goto skip1;
-		case 2:	c1 = ((unsigned char *)save)[1];
-			c2 = ((unsigned char *)save)[2]; goto skip2;
-		}
-		
-		/* yes, we jump into the loop, no i'm not going to change it, its beautiful! */
-		while (inptr < inend) {
-			c1 = *inptr++;
-		skip1:
-			c2 = *inptr++;
-		skip2:
-			c3 = *inptr++;
-			*outptr++ = base64_alphabet [c1 >> 2];
-			*outptr++ = base64_alphabet [(c2 >> 4) | ((c1 & 0x3) << 4)];
-			*outptr++ = base64_alphabet [((c2 & 0x0f) << 2) | (c3 >> 6)];
-			*outptr++ = base64_alphabet [c3 & 0x3f];
-			/* this is a bit ugly ... */
-			if ((++already) >= 19) {
-				*outptr++ = '\n';
-				already = 0;
-			}
-		}
-		
-		((unsigned char *)save)[0] = 0;
-		inlen = 2 - (inptr - inend);
-		*state = already;
-	}
-	
-	d(printf ("state = %d, inlen = %d\n", (int)((char *)save)[0], inlen));
-	
-	if (inlen > 0) {
-		register char *saveout;
-		
-		/* points to the slot for the next char to save */
-		saveout = & (((char *)save)[1]) + ((char *)save)[0];
-		
-		/* inlen can only be 0, 1 or 2 */
-		switch (inlen) {
-		case 2:	*saveout++ = *inptr++;
-		case 1:	*saveout++ = *inptr++;
-		}
-		((char *)save)[0] += (char) inlen;
-	}
-	
-	d(printf ("mode = %d\nc1 = %c\nc2 = %c\n",
-		  (int)((char *)save)[0],
-		  (int)((char *)save)[1],
-		  (int)((char *)save)[2]));
-	
-	return (outptr - outbuf);
+	gint glib_save;
+	gsize glib_res;
+
+	glib_save = *save;
+	glib_res = g_base64_encode_step ((const guchar *) inbuf, inlen, TRUE, (gchar *) outbuf, state, &glib_save);
+	*save = glib_save;
+
+	return glib_res;
 }
 
 
@@ -507,66 +412,14 @@ g_mime_encoding_base64_encode_step (const unsigned char *inbuf, size_t inlen, un
 size_t
 g_mime_encoding_base64_decode_step (const unsigned char *inbuf, size_t inlen, unsigned char *outbuf, int *state, guint32 *save)
 {
-	register const unsigned char *inptr;
-	register unsigned char *outptr;
-	const unsigned char *inend;
-	register guint32 saved;
-	unsigned char c;
-	int npad, n, i;
-	
-	inend = inbuf + inlen;
-	outptr = outbuf;
-	inptr = inbuf;
-	
-	npad = (*state >> 8) & 0xff;
-	n = *state & 0xff;
-	saved = *save;
-	
-	/* convert 4 base64 bytes to 3 normal bytes */
-	while (inptr < inend) {
-		c = gmime_base64_rank[*inptr++];
-		if (c != 0xff) {
-			saved = (saved << 6) | c;
-			n++;
-			if (n == 4) {
-				*outptr++ = saved >> 16;
-				*outptr++ = saved >> 8;
-				*outptr++ = saved;
-				n = 0;
-				
-				if (npad > 0) {
-					outptr -= npad;
-					npad = 0;
-				}
-			}
-		}
-	}
-	
-	/* quickly scan back for '=' on the end somewhere */
-	/* fortunately we can drop 1 output char for each trailing '=' (up to 2) */
-	for (i = 2; inptr > inbuf && i; ) {
-		inptr--;
-		if (gmime_base64_rank[*inptr] != 0xff) {
-			if (*inptr == '=' && outptr > outbuf) {
-				if (n == 0) {
-					/* we've got a complete quartet so it's
-					   safe to drop an output character. */
-					outptr--;
-				} else if (npad < 2) {
-					/* keep a record of the number of ='s at
-					   the end of the input stream, up to 2 */
-					npad++;
-				}
-			}
-			
-			i--;
-		}
-	}
-	
-	*state = (npad << 8) | n;
-	*save = n ? saved : 0;
-	
-	return (outptr - outbuf);
+	guint glib_save;
+	gsize glib_res;
+
+	glib_save = *save;
+	glib_res = g_base64_decode_step ((const gchar *) inbuf, inlen, outbuf, state, &glib_save);
+	*save = glib_save;
+
+	return glib_res;
 }
 
 


### PR DESCRIPTION
Replace the custom Base64 encoding and decoding functions by wrappers for the corresponding GLib functions. As the latter decode Base64 blocks consisting of several consecutive '='-terminated chunks properly, this also fixes the bug that the GMime functions inserted a NUL-byte at the end of each chunk. See slide 31 of <https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Veranstaltungen/ITSiKongress/15ter/Vortraege_17-05-2017/SteffenUllrich.pdf?__blob=publicationFile&v=2> why this bug might be critical.

Note that the GLib functions use different data types for the saved states (state and save). While int and gint (state) are actually the same, GLib uses at most 24 bits in save which always fits into the 32-bit unsigned used by GMime.