### PR TITLE
Implement basic error reporting for the GMime parser

### DIFF
--- a/docs/reference/gmime-sections.txt
+++ b/docs/reference/gmime-sections.txt
@@ -1284,6 +1284,8 @@ GMIME_TYPE_FORMAT_OPTIONS
 <FILE>gmime-parser-options</FILE>
 GMimeParserOptions
 GMimeRfcComplianceMode
+GMimeParserWarning
+GMimeParserWarningFunc
 g_mime_parser_options_new
 g_mime_parser_options_free
 g_mime_parser_options_clone
@@ -1298,6 +1300,8 @@ g_mime_parser_options_get_rfc2047_compliance_mode
 g_mime_parser_options_set_rfc2047_compliance_mode
 g_mime_parser_options_get_fallback_charsets
 g_mime_parser_options_set_fallback_charsets
+g_mime_parser_options_get_warning_callback
+g_mime_parser_options_set_warning_callback
 
 <SUBSECTION Private>
 g_mime_parser_options_get_type

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -6,7 +6,7 @@ extra_DIST = README
 
 AM_CPPFLAGS = -I$(top_srcdir) $(GMIME_CFLAGS) $(GLIB_CFLAGS)
 
-noinst_PROGRAMS = basic-example imap-example uuencode uudecode
+noinst_PROGRAMS = basic-example imap-example uuencode uudecode msgcheck
 
 DEPS = 						\
 	$(top_builddir)/util/libutil.la		\
@@ -42,3 +42,8 @@ uudecode_SOURCES = $(GETOPT_SOURCES) uudecode.c
 uudecode_LDFLAGS = 
 uudecode_DEPENDENCIES = $(DEPS)
 uudecode_LDADD = $(LDADDS)
+
+msgcheck_SOURCES = $(GETOPT_SOURCES) msgcheck.c
+msgcheck_LDFLAGS = 
+msgcheck_DEPENDENCIES = $(DEPS)
+msgcheck_LDADD = $(LDADDS)

--- a/examples/msgcheck.c
+++ b/examples/msgcheck.c
@@ -1,0 +1,155 @@
+/*
+ *  Example application demonstrating the GMime parser's feature for
+ *  detecting and reporting RFC violations in messages.
+ *
+ *  Written by (C) Albrecht Dreß <albrecht.dress@arcor.de> 2017
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <stdlib.h>
+#include <gmime/gmime.h>
+
+
+typedef struct {
+	gint64 offset;
+	GMimeParserWarning errcode;
+	gchar *message;
+} issue_log_elem_t;
+
+
+static const gchar *
+errcode2str(GMimeParserWarning errcode)
+{
+	switch (errcode) {
+	case GMIME_WARN_DUPLICATED_CONTENT_HDR:
+		return "duplicated content header";
+	case GMIME_WARN_DUPLICATED_PARAMETER:
+		return "duplicated header parameter";
+	case GMIME_WARN_UNENCODED_8BIT_HEADER:
+		return "unencoded 8-bit characters in header";
+	case GMIME_WARN_INVALID_CONTENT_TYPE:
+		return "invalid Content-Type";
+	case GMIME_WARN_INVALID_HEADER:
+		return "invalid header";
+	case GMIME_WARN_MALFORMED_MULTIPART:
+		return "malformed multipart";
+	case GMIME_WARN_TRUNCATED_MESSAGE:
+		return "truncated message";
+	case GMIME_WARN_MALFORMED_MESSAGE:
+		return "malformed message";
+	case GMIME_CRIT_CONFLICTING_CONTENT_HDR:
+		return "conflicting content header";
+	case GMIME_CRIT_CONFLICTING_PARAMETER:
+		return "conflicting header parameter";
+	case GMIME_CRIT_MULTIPART_WITHOUT_BOUNDARY:
+		return "multipart without boundary";
+	default:
+		return "unknown";
+	}
+}
+
+
+static void
+parser_issue (gint64 offset, GMimeParserWarning errcode, const gchar *item, gpointer user_data)
+{
+	GList **issues = (GList **) user_data;
+	issue_log_elem_t *new_issue;
+
+	new_issue = g_new (issue_log_elem_t, 1U);
+	new_issue->offset = offset;
+	new_issue->errcode = errcode;
+	if (item == NULL) {
+		new_issue->message = g_strdup (errcode2str (errcode));
+	} else {
+		gchar *buf;
+
+		buf = g_strdup (item);
+		g_strstrip (buf);
+		new_issue->message = g_strdup_printf ("%s: '%s'", errcode2str (errcode), buf);
+		g_free (buf);
+	}
+	*issues = g_list_append (*issues, new_issue);
+}
+
+
+static void
+check_msg_file (const gchar *filename)
+{
+	GMimeStream *stream;
+	GError *error = NULL;
+
+	stream = g_mime_stream_file_open (filename, "r", &error);
+
+	if (stream == NULL) {
+		g_warning ("failed to open %s: %s", filename, error->message);
+		g_error_free (error);
+	} else {
+		GMimeParser *parser;
+		GMimeParserOptions *options;
+		GMimeMessage *message;
+		GList *issues = NULL;
+
+		parser = g_mime_parser_new ();
+		g_mime_parser_init_with_stream (parser, stream);
+		options = g_mime_parser_options_new ();
+		g_mime_parser_options_set_warning_callback (options, parser_issue, &issues);
+		message = g_mime_parser_construct_message (parser, options);
+		g_mime_parser_options_free (options);
+		g_object_unref (parser);
+		g_object_unref (stream);
+		if (message != NULL) {
+			g_object_unref (message);
+		}
+
+		if (issues == NULL) {
+			g_printf ("%s: message looks benign\n", filename);
+		} else {
+			GList *this_issue;
+
+			g_printf ("%s: message contains %u RFC violations:\n", filename, g_list_length (issues));
+			for (this_issue = issues; this_issue != NULL; this_issue = this_issue->next) {
+				issue_log_elem_t *issue_data = (issue_log_elem_t *) this_issue->data;
+
+				g_printf ("offset %" G_GINT64_FORMAT ": [%u] %s\n",
+					issue_data->offset, issue_data->errcode, issue_data->message);
+				g_free (issue_data->message);
+				g_free (issue_data);
+			}
+			g_list_free (issues);
+		}
+	}
+}
+
+
+int
+main (int argc, char **argv)
+{
+	int n;
+
+	if (argc < 2) {
+		g_message ("usage: %s <filename> [<filename> ...]", argv[0]);
+		exit (1);
+	}
+
+	g_mime_init ();
+
+	for (n = 1; n < argc; n++) {
+		check_msg_file (argv[n]);
+	}
+
+	g_mime_shutdown ();
+	return 0;
+}

--- a/gmime/gmime-disposition.c
+++ b/gmime/gmime-disposition.c
@@ -29,6 +29,7 @@
 #include "gmime-common.h"
 #include "gmime-disposition.h"
 #include "gmime-events.h"
+#include "gmime-internal.h"
 
 
 /**
@@ -148,6 +149,12 @@ g_mime_content_disposition_new (void)
 GMimeContentDisposition *
 g_mime_content_disposition_parse (GMimeParserOptions *options, const char *str)
 {
+	return _g_mime_content_disposition_parse (options, str, -1);
+}
+
+GMimeContentDisposition *
+_g_mime_content_disposition_parse (GMimeParserOptions *options, const char *str, gint64 offset)
+{
 	GMimeContentDisposition *disposition;
 	const char *inptr = str;
 	GMimeParamList *params;
@@ -168,7 +175,7 @@ g_mime_content_disposition_parse (GMimeParserOptions *options, const char *str)
 	disposition->disposition = g_strstrip (value);
 	
 	/* parse the parameters, if any */
-	if (*inptr++ == ';' && *inptr && (params = g_mime_param_list_parse (options, inptr))) {
+	if (*inptr++ == ';' && *inptr && (params = _g_mime_param_list_parse (options, inptr, offset))) {
 		g_mime_event_add (params->changed, (GMimeEventCallback) param_list_changed, disposition);
 		g_object_unref (disposition->params);
 		disposition->params = params;

--- a/gmime/gmime-encodings.c
+++ b/gmime/gmime-encodings.c
@@ -54,27 +54,6 @@
 #define GMIME_UUENCODE_CHAR(c) ((c) ? (c) + ' ' : '`')
 #define	GMIME_UUDECODE_CHAR(c) (((c) - ' ') & 077)
 
-static char base64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-static unsigned char gmime_base64_rank[256] = {
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255, 62,255,255,255, 63,
-	 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,255,255,255,  0,255,255,
-	255,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-	 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,255,255,255,255,255,
-	255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-	 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-};
-
 static unsigned char gmime_uu_rank[256] = {
 	 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
 	 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
@@ -371,35 +350,20 @@ g_mime_encoding_flush (GMimeEncoding *state, const char *inbuf, size_t inlen, ch
 size_t
 g_mime_encoding_base64_encode_close (const unsigned char *inbuf, size_t inlen, unsigned char *outbuf, int *state, guint32 *save)
 {
-	unsigned char *outptr = outbuf;
-	int c1, c2;
-	
-	if (inlen > 0)
-		outptr += g_mime_encoding_base64_encode_step (inbuf, inlen, outptr, state, save);
-	
-	c1 = ((unsigned char *)save)[1];
-	c2 = ((unsigned char *)save)[2];
-	
-	switch (((unsigned char *)save)[0]) {
-	case 2:
-		outptr[2] = base64_alphabet [(c2 & 0x0f) << 2];
-		goto skip;
-	case 1:
-		outptr[2] = '=';
-	skip:
-		outptr[0] = base64_alphabet [c1 >> 2];
-		outptr[1] = base64_alphabet [c2 >> 4 | ((c1 & 0x3) << 4)];
-		outptr[3] = '=';
-		outptr += 4;
-		break;
+	gint glib_save;
+	gsize glib_res;
+
+	glib_save = *save;
+	if (inlen > 0U) {
+		glib_res = g_base64_encode_step ((const guchar *) inbuf, inlen, TRUE, (gchar *) outbuf, state, &glib_save);
+		outbuf = &outbuf[glib_res];
+	} else {
+		glib_res = 0U;
 	}
-	
-	*outptr++ = '\n';
-	
-	*save = 0;
-	*state = 0;
-	
-	return (outptr - outbuf);
+	glib_res += g_base64_encode_close (TRUE, (gchar *) outbuf, state, &glib_save);
+	*save = glib_save;
+
+	return glib_res;
 }
 
 
@@ -421,73 +385,14 @@ g_mime_encoding_base64_encode_close (const unsigned char *inbuf, size_t inlen, u
 size_t
 g_mime_encoding_base64_encode_step (const unsigned char *inbuf, size_t inlen, unsigned char *outbuf, int *state, guint32 *save)
 {
-	register const unsigned char *inptr;
-	register unsigned char *outptr;
-	
-	if (inlen == 0)
-		return 0;
-	
-	outptr = outbuf;
-	inptr = inbuf;
-	
-	if (inlen + ((unsigned char *)save)[0] > 2) {
-		const unsigned char *inend = inbuf + inlen - 2;
-		register int c1 = 0, c2 = 0, c3 = 0;
-		register int already;
-		
-		already = *state;
-		
-		switch (((char *)save)[0]) {
-		case 1:	c1 = ((unsigned char *)save)[1]; goto skip1;
-		case 2:	c1 = ((unsigned char *)save)[1];
-			c2 = ((unsigned char *)save)[2]; goto skip2;
-		}
-		
-		/* yes, we jump into the loop, no i'm not going to change it, its beautiful! */
-		while (inptr < inend) {
-			c1 = *inptr++;
-		skip1:
-			c2 = *inptr++;
-		skip2:
-			c3 = *inptr++;
-			*outptr++ = base64_alphabet [c1 >> 2];
-			*outptr++ = base64_alphabet [(c2 >> 4) | ((c1 & 0x3) << 4)];
-			*outptr++ = base64_alphabet [((c2 & 0x0f) << 2) | (c3 >> 6)];
-			*outptr++ = base64_alphabet [c3 & 0x3f];
-			/* this is a bit ugly ... */
-			if ((++already) >= 19) {
-				*outptr++ = '\n';
-				already = 0;
-			}
-		}
-		
-		((unsigned char *)save)[0] = 0;
-		inlen = 2 - (inptr - inend);
-		*state = already;
-	}
-	
-	d(printf ("state = %d, inlen = %d\n", (int)((char *)save)[0], inlen));
-	
-	if (inlen > 0) {
-		register char *saveout;
-		
-		/* points to the slot for the next char to save */
-		saveout = & (((char *)save)[1]) + ((char *)save)[0];
-		
-		/* inlen can only be 0, 1 or 2 */
-		switch (inlen) {
-		case 2:	*saveout++ = *inptr++;
-		case 1:	*saveout++ = *inptr++;
-		}
-		((char *)save)[0] += (char) inlen;
-	}
-	
-	d(printf ("mode = %d\nc1 = %c\nc2 = %c\n",
-		  (int)((char *)save)[0],
-		  (int)((char *)save)[1],
-		  (int)((char *)save)[2]));
-	
-	return (outptr - outbuf);
+	gint glib_save;
+	gsize glib_res;
+
+	glib_save = *save;
+	glib_res = g_base64_encode_step ((const guchar *) inbuf, inlen, TRUE, (gchar *) outbuf, state, &glib_save);
+	*save = glib_save;
+
+	return glib_res;
 }
 
 
@@ -507,66 +412,14 @@ g_mime_encoding_base64_encode_step (const unsigned char *inbuf, size_t inlen, un
 size_t
 g_mime_encoding_base64_decode_step (const unsigned char *inbuf, size_t inlen, unsigned char *outbuf, int *state, guint32 *save)
 {
-	register const unsigned char *inptr;
-	register unsigned char *outptr;
-	const unsigned char *inend;
-	register guint32 saved;
-	unsigned char c;
-	int npad, n, i;
-	
-	inend = inbuf + inlen;
-	outptr = outbuf;
-	inptr = inbuf;
-	
-	npad = (*state >> 8) & 0xff;
-	n = *state & 0xff;
-	saved = *save;
-	
-	/* convert 4 base64 bytes to 3 normal bytes */
-	while (inptr < inend) {
-		c = gmime_base64_rank[*inptr++];
-		if (c != 0xff) {
-			saved = (saved << 6) | c;
-			n++;
-			if (n == 4) {
-				*outptr++ = saved >> 16;
-				*outptr++ = saved >> 8;
-				*outptr++ = saved;
-				n = 0;
-				
-				if (npad > 0) {
-					outptr -= npad;
-					npad = 0;
-				}
-			}
-		}
-	}
-	
-	/* quickly scan back for '=' on the end somewhere */
-	/* fortunately we can drop 1 output char for each trailing '=' (up to 2) */
-	for (i = 2; inptr > inbuf && i; ) {
-		inptr--;
-		if (gmime_base64_rank[*inptr] != 0xff) {
-			if (*inptr == '=' && outptr > outbuf) {
-				if (n == 0) {
-					/* we've got a complete quartet so it's
-					   safe to drop an output character. */
-					outptr--;
-				} else if (npad < 2) {
-					/* keep a record of the number of ='s at
-					   the end of the input stream, up to 2 */
-					npad++;
-				}
-			}
-			
-			i--;
-		}
-	}
-	
-	*state = (npad << 8) | n;
-	*save = n ? saved : 0;
-	
-	return (outptr - outbuf);
+	guint glib_save;
+	gsize glib_res;
+
+	glib_save = *save;
+	glib_res = g_base64_decode_step ((const gchar *) inbuf, inlen, outbuf, state, &glib_save);
+	*save = glib_save;
+
+	return glib_res;
 }
 
 

--- a/gmime/gmime-internal.h
+++ b/gmime/gmime-internal.h
@@ -50,6 +50,8 @@ G_GNUC_INTERNAL GMimeFormatOptions *_g_mime_format_options_clone (GMimeFormatOpt
 /* GMimeParserOptions */
 G_GNUC_INTERNAL void g_mime_parser_options_init (void);
 G_GNUC_INTERNAL void g_mime_parser_options_shutdown (void);
+G_GNUC_INTERNAL void _g_mime_parser_options_warn (GMimeParserOptions *options, gint64 offset, GMimeParserWarning errcode,
+						  const gchar *item);
 
 /* GMimeHeader */
 //G_GNUC_INTERNAL void _g_mime_header_set_raw_value (GMimeHeader *header, const char *raw_value);
@@ -68,6 +70,16 @@ G_GNUC_INTERNAL void _g_mime_object_unblock_header_list_changed (GMimeObject *ob
 G_GNUC_INTERNAL void _g_mime_object_set_content_type (GMimeObject *object, GMimeContentType *content_type);
 G_GNUC_INTERNAL void _g_mime_object_append_header (GMimeObject *object, const char *name, const char *raw_name,
 						   const char *raw_value, gint64 offset);
+
+/* GMimeContentType */
+G_GNUC_INTERNAL GMimeContentType *_g_mime_content_type_parse (GMimeParserOptions *options, const char *str, gint64 offset);
+
+/* GMimeParamList */
+G_GNUC_INTERNAL GMimeParamList *_g_mime_param_list_parse (GMimeParserOptions *options, const char *str, gint64 offset);
+
+/* GMimeContentDisposition */
+G_GNUC_INTERNAL GMimeContentDisposition *_g_mime_content_disposition_parse (GMimeParserOptions *options, const char *str,
+									    gint64 offset);
 
 /* utils */
 G_GNUC_INTERNAL char *_g_mime_utils_unstructured_header_fold (GMimeParserOptions *options, GMimeFormatOptions *format,

--- a/gmime/gmime-object.c
+++ b/gmime/gmime-object.c
@@ -213,13 +213,13 @@ object_header_changed (GMimeObject *object, GMimeHeader *header)
 	switch (i) {
 	case HEADER_CONTENT_DISPOSITION:
 		value = g_mime_header_get_value (header);
-		disposition = g_mime_content_disposition_parse (options, value);
+		disposition = _g_mime_content_disposition_parse (options, value, header->offset);
 		_g_mime_object_set_content_disposition (object, disposition);
 		g_object_unref (disposition);
 		break;
 	case HEADER_CONTENT_TYPE:
 		value = g_mime_header_get_value (header);
-		content_type = g_mime_content_type_parse (options, value);
+		content_type = _g_mime_content_type_parse (options, value, header->offset);
 		_g_mime_object_set_content_type (object, content_type);
 		g_object_unref (content_type);
 		break;

--- a/gmime/gmime-parser-options.h
+++ b/gmime/gmime-parser-options.h
@@ -42,11 +42,53 @@ typedef enum {
 } GMimeRfcComplianceMode;
 
 /**
+ * GMimeParserWarning:
+ * @GMIME_WARN_DUPLICATED_CONTENT_HDR: repeated exactly the same `Content-*` header
+ * @GMIME_WARN_DUPLICATED_PARAMETER: repeated exactly the same header parameter
+ * @GMIME_WARN_UNENCODED_8BIT_HEADER: a header contains unencoded 8-bit characters
+ * @GMIME_WARN_INVALID_CONTENT_TYPE: invalid content type, assume `application/octet-stream`
+ * @GMIME_WARN_INVALID_HEADER: invalid header, ignored
+ * @GMIME_WARN_MALFORMED_MULTIPART: no items in a `multipart/...`
+ * @GMIME_WARN_TRUNCATED_MESSAGE: the message is truncated
+ * @GMIME_WARN_MALFORMED_MESSAGE: the message is malformed
+ * @GMIME_CRIT_CONFLICTING_CONTENT_HDR: conflicting `Content-*` header
+ * @GMIME_CRIT_CONFLICTING_PARAMETER: conflicting header parameter
+ * @GMIME_CRIT_MULTIPART_WITHOUT_BOUNDARY: a `multipart/...` part lacks the required boundary parameter
+ *
+ * Issues the @GMimeParser detects. Note that the `GMIME_CRIT_*` issues indicate that some parts of the @GMimeParser input may
+ * be ignored or will be interpreted differently by other software products.
+ **/
+typedef enum {
+	GMIME_WARN_DUPLICATED_CONTENT_HDR = 1U,
+	GMIME_WARN_DUPLICATED_PARAMETER,
+	GMIME_WARN_UNENCODED_8BIT_HEADER,
+	GMIME_WARN_INVALID_CONTENT_TYPE,
+	GMIME_WARN_INVALID_HEADER,
+	GMIME_WARN_MALFORMED_MULTIPART,
+	GMIME_WARN_TRUNCATED_MESSAGE,
+	GMIME_WARN_MALFORMED_MESSAGE,
+	GMIME_CRIT_CONFLICTING_CONTENT_HDR,
+	GMIME_CRIT_CONFLICTING_PARAMETER,
+	GMIME_CRIT_MULTIPART_WITHOUT_BOUNDARY
+} GMimeParserWarning;
+
+/**
  * GMimeParserOptions:
  *
  * A set of parser options used by #GMimeParser and various other parsing functions.
  **/
 typedef struct _GMimeParserOptions GMimeParserOptions;
+
+/**
+ * GMimeParserWarningFunc:
+ * @offset: parser offset where the issue has been detected, or -1 if it is unknown
+ * @errcode: a #GMimeParserWarning
+ * @item: a NUL-terminated string containing the value causing the issue, may be %NULL
+ * @user_data: User-supplied callback data.
+ *
+ * The function signature for a callback to g_mime_parser_options_set_warning_callback().
+ **/
+typedef void (*GMimeParserWarningFunc) (gint64 offset, GMimeParserWarning errcode, const gchar *item, gpointer user_data);
 
 
 GType g_mime_parser_options_get_type (void);
@@ -72,6 +114,10 @@ void g_mime_parser_options_set_rfc2047_compliance_mode (GMimeParserOptions *opti
 
 const char **g_mime_parser_options_get_fallback_charsets (GMimeParserOptions *options);
 void g_mime_parser_options_set_fallback_charsets (GMimeParserOptions *options, const char **charsets);
+
+GMimeParserWarningFunc g_mime_parser_options_get_warning_callback (GMimeParserOptions *options);
+void g_mime_parser_options_set_warning_callback (GMimeParserOptions *options, GMimeParserWarningFunc warning_cb,
+						 gpointer user_data);
 
 G_END_DECLS
 


### PR DESCRIPTION
This patch is the first real attempt to implement an error reporting facility for the GMime parser.  Basically, it extends GMimeParserOptions by a callback which is called whenever the parser detects a “fishy” construct.  The callback receives the offset within the message, an error code and (if applicable) an additional string, plus a user-defined data pointer.  I do not add the GMime object to the callback as it is difficult to pass it downstream to the functions where the error is detected, and I don't think it provides much usable information for the caller anyway.

The errors reported are at the moment:
- non-conflicting Content-* headers (i.e. exactly the same header ist repeated)
- non-conflicting header parameters (ditto)
- unencoded 8-bit characters in headers
- invalid content-type headers and completely broken headers
- malformed multipart/* and malformed messages
- truncated messages
- conflicting Content-* headers (i.e. different Content-* headers for the same part)
- conflicting header parameters (ditto)
- multipart without boundary

Whilst most of them are typically indications for broken (spam) senders, the last three may actually be used to evade security mechanisms and thus could be an indication for an attack.

I added a trivial example application which scans one or more message/rfc822 files (e.g. the elements in a maildir folder) for issues.

A possible extension which might make sense would be reporting all RFC 2047 header formatting violations (typical for broken spam senders).

The patch does not cover issues like missing required headers, chunked base64 encoded parts ('=' inside the block), etc., which should be handled at a higher level (i.e. by inspecting the resulting message object).

Details:
* docs/reference/gmime-sections.txt
  add new functions and data types to the docs
* examples/Makefile.am, examples/msgcheck.c
  add example application
* gmime/gmime-content-type.c
  rename g_mime_content_type_parse() to _g_mime_content_type_parse() taking an extra offset parameter, and make g_mime_content_type_parse() a wrapper to the latter.  Call the callback helper for an invalid content type, and pass the offset to the parameter list parser.
* gmime/gmime-disposition.c
  rename g_mime_content_disposition_parse() to _g_mime_content_disposition_parse() taking an extra offset parameter, and make g_mime_content_disposition_parse() a wrapper to the latter.  Pass the offset to the parameter list parser.
* gmime/gmime-internal.h
  define the callback helper and the renamed functions taking the extra offset parameter
* gmime/gmime-object.c
  call the renamed functions taking the extra offset parameter
* gmime/gmime-param.c
  decode_param_list(): add offset parameter, and call the callback helper if a duplicated or conflicting parameter is detected
  rename g_mime_param_list_parse() to _g_mime_param_list_parse() taking an extra offset parameter, and make g_mime_param_list_parse() a wrapper to the latter.
* gmime/gmime-parser-options.c
  * add the callback and the user data pointer to GMimeParserOptions, and properly initialise and copy them
  * add helpers to set and retrieve the callback
  * add a helper to call the callback if it has been defined
* gmime/gmime-parser-options.h
  declare GMimeParserWarning (error codes) and the public helpers
* gmime/gmime-parser.c
  * parser_find_header(): search the Content-Type header from the _end_ of the list so GMime consistently uses the last one.  Otherwise, a part with conflicting Content-Type headers would never be processed.
  * is_7bit_clean(): new function, does exactly this
  * header_parse(): extra offset parameter, call the callback helper for invalid headers or headers containing 8-bit chars
  * parser_step_headers(), parser_step(): extra GMimeParserOptions parameter
  * check_content_header_conflict(): new helper function, call the callback helper for duplicated or conflicting header
  * parser_construct_leaf_part(): check for duplicated or conflicting Content-* header
  * parser_construct_multipart(): check for duplicated or conflicting Content-* header, call the callback helper for malformed multipart, multipart without boundary and truncated messages
  * parser_construct_message(): apply passed GMimeParserOptions to header list, call the callback helper for malformed messages