### PR TITLE
Autocrypt: move keydata to GBytes instead of GByteArray

### DIFF
--- a/gmime/gmime-autocrypt.h
+++ b/gmime/gmime-autocrypt.h
@@ -80,7 +80,7 @@ struct _GMimeAutocryptHeader {
 
 	InternetAddressMailbox *address;
 	GMimeAutocryptPreferEncrypt prefer_encrypt;
-	GByteArray *keydata;
+	GBytes *keydata;
 	GDateTime *effective_date;
 };
 
@@ -101,8 +101,8 @@ const char *g_mime_autocrypt_header_get_address_as_string (GMimeAutocryptHeader 
 void g_mime_autocrypt_header_set_prefer_encrypt (GMimeAutocryptHeader *ah, GMimeAutocryptPreferEncrypt pref);
 GMimeAutocryptPreferEncrypt g_mime_autocrypt_header_get_prefer_encrypt (GMimeAutocryptHeader *ah);
 
-void g_mime_autocrypt_header_set_keydata (GMimeAutocryptHeader *ah, GByteArray *data);
-GByteArray *g_mime_autocrypt_header_get_keydata (GMimeAutocryptHeader *ah);
+void g_mime_autocrypt_header_set_keydata (GMimeAutocryptHeader *ah, GBytes *data);
+GBytes *g_mime_autocrypt_header_get_keydata (GMimeAutocryptHeader *ah);
 
 void g_mime_autocrypt_header_set_effective_date (GMimeAutocryptHeader *ah, GDateTime *effective_date);
 GDateTime *g_mime_autocrypt_header_get_effective_date (GMimeAutocryptHeader *ah);

--- a/tests/test-autocrypt.c
+++ b/tests/test-autocrypt.c
@@ -47,7 +47,7 @@ static GMimeAutocryptHeader*
 _gen_header (const struct _ah_gen_test *t)
 {
 	GMimeAutocryptHeader *ah = NULL;
-	GByteArray *keydata = NULL;
+	GBytes *keydata = NULL;
 	if (t == NULL)
 		return NULL;
 	if (!(ah = g_mime_autocrypt_header_new())) {
@@ -55,7 +55,7 @@ _gen_header (const struct _ah_gen_test *t)
 		return NULL;
 	}
 	if (t->keydatacount)
-		if (!(keydata = g_byte_array_new_take ((guint8*) g_strnfill (t->keydatacount, t->keybyte), t->keydatacount))) {
+		if (!(keydata = g_bytes_new_take ((guint8*) g_strnfill (t->keydatacount, t->keybyte), t->keydatacount))) {
 			fprintf (stderr, "failed to make a new keydata");
 			g_object_unref (ah);
 			return NULL;
@@ -68,7 +68,7 @@ _gen_header (const struct _ah_gen_test *t)
 		g_date_time_unref (ts);
 	}
 	if (keydata)
-		g_byte_array_unref (keydata);
+		g_bytes_unref (keydata);
 	return ah;
 }
 


### PR DESCRIPTION
There's no reason that the keydata should be mutable, so use GBytes
instead.