### PR TITLE
Autocrypt header injection

### DIFF
--- a/docs/reference/gmime-sections.txt
+++ b/docs/reference/gmime-sections.txt
@@ -1004,6 +1004,7 @@ g_mime_message_get_body
 g_mime_message_get_autocrypt_header
 g_mime_message_get_autocrypt_gossip_headers_from_inner_part
 g_mime_message_get_autocrypt_gossip_headers
+g_mime_message_add_autocrypt_header
 
 <SUBSECTION Private>
 g_mime_message_get_type

--- a/docs/reference/gmime-sections.txt
+++ b/docs/reference/gmime-sections.txt
@@ -794,6 +794,7 @@ g_mime_object_get_header_list
 g_mime_object_write_to_stream
 g_mime_object_to_string
 g_mime_object_encode
+g_mime_object_add_autocrypt_gossip_headers
 
 <SUBSECTION Private>
 g_mime_object_get_type

--- a/gmime/gmime-autocrypt.c
+++ b/gmime/gmime-autocrypt.c
@@ -466,7 +466,7 @@ g_mime_autocrypt_header_get_string (GMimeAutocryptHeader *ah)
 
 	g_ptr_array_add (lines, NULL);
 
-	char *ret = g_strjoinv ("\r\n ", (gchar**)(lines->pdata));
+	char *ret = g_strjoinv (" ", (gchar**)(lines->pdata));
 	g_ptr_array_unref (lines);
 	return ret;
 }

--- a/gmime/gmime-message.c
+++ b/gmime/gmime-message.c
@@ -1371,3 +1371,21 @@ GMimeAutocryptHeaderList *g_mime_message_get_autocrypt_gossip_headers (GMimeMess
 
 	return ret;
 }
+
+
+/**
+ * g_mime_message_add_autocrypt_header:
+ * @message: a #GMimeMessage object
+ * @header: a #GMimeAutocrypt object
+ *
+ * Adds the textual form of @header to @message.
+ **/
+void g_mime_message_add_autocrypt_header (GMimeMessage *message, GMimeAutocryptHeader *header)
+{
+	g_return_if_fail (GMIME_IS_MESSAGE (message));
+	g_return_if_fail (GMIME_IS_AUTOCRYPT_HEADER (header));
+	
+	char *h = g_mime_autocrypt_header_get_string (header);
+	g_mime_object_set_header ((GMimeObject *) message, "Autocrypt", h, NULL);
+	g_free (h);
+}

--- a/gmime/gmime-message.h
+++ b/gmime/gmime-message.h
@@ -128,6 +128,8 @@ GMimeAutocryptHeader *g_mime_message_get_autocrypt_header (GMimeMessage *message
 GMimeAutocryptHeaderList *g_mime_message_get_autocrypt_gossip_headers (GMimeMessage *message, GDateTime *now, GMimeDecryptFlags flags, const char *session_key, GError **err);
 GMimeAutocryptHeaderList *g_mime_message_get_autocrypt_gossip_headers_from_inner_part (GMimeMessage *message, GDateTime *now, GMimeObject *inner_part);
 
+void g_mime_message_add_autocrypt_header (GMimeMessage *message, GMimeAutocryptHeader *header);
+
 /* convenience functions */
 
 void g_mime_message_foreach (GMimeMessage *message, GMimeObjectForeachFunc callback,

--- a/gmime/gmime-object.c
+++ b/gmime/gmime-object.c
@@ -1157,3 +1157,31 @@ g_mime_object_get_autocrypt_headers (GMimeObject *mime_part, GDateTime *effectiv
 		g_mime_autocrypt_header_list_remove_incomplete (ret);
 	return ret;
 }
+
+
+/**
+ * g_mime_object_add_gossip_headers:
+ * @object: a #GMimeObject
+ *
+ * Get the header list for @object.
+ *
+ * Returns: (transfer none): the #GMimeHeaderList for @object. Do not
+ * free this pointer when you are done with it.
+ **/
+void g_mime_object_add_autocrypt_gossip_headers (GMimeObject *object, GMimeAutocryptHeaderList* ahl)
+{
+	g_return_if_fail (GMIME_IS_OBJECT (object));
+	g_return_if_fail (GMIME_IS_AUTOCRYPT_HEADER_LIST (ahl));
+	int i;
+	int count = g_mime_autocrypt_header_list_get_count (ahl);
+	for (i = 0; i < count; i++) {
+		GMimeAutocryptHeader *ah = g_mime_autocrypt_header_list_get_header_at (ahl, i);
+		GMimeAutocryptPreferEncrypt old = g_mime_autocrypt_header_get_prefer_encrypt (ah);
+		g_mime_autocrypt_header_set_prefer_encrypt (ah, GMIME_AUTOCRYPT_PREFER_ENCRYPT_NONE);
+		char *h = g_mime_autocrypt_header_get_string (ah);
+
+		g_mime_object_append_header (object, "Autocrypt-Gossip", h, NULL);
+		g_free (h);
+		g_mime_autocrypt_header_set_prefer_encrypt (ah, old);
+	}
+}

--- a/gmime/gmime-object.h
+++ b/gmime/gmime-object.h
@@ -137,6 +137,7 @@ ssize_t g_mime_object_write_to_stream (GMimeObject *object, GMimeFormatOptions *
 char *g_mime_object_to_string (GMimeObject *object, GMimeFormatOptions *options);
 
 void g_mime_object_encode (GMimeObject *object, GMimeEncodingConstraint constraint);
+void g_mime_object_add_autocrypt_gossip_headers (GMimeObject *object, GMimeAutocryptHeaderList* ahl);
 
 /* Internal API */
 G_GNUC_INTERNAL void g_mime_object_type_registry_init (void);

--- a/tests/test-autocrypt.c
+++ b/tests/test-autocrypt.c
@@ -94,8 +94,8 @@ const static struct _ah_gen_test gen_test_data[] = {
 	{ .addr = "test@example.org",
 	  .keydatacount = 102,
 	  .keybyte = '\013',
-	  .txt = "addr=test@example.org; keydata=CwsLCwsLCwsLCwsLCwsLCwsLCwsL\r\n"
-	  " CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsL\r\n"
+	  .txt = "addr=test@example.org; keydata=CwsLCwsLCwsLCwsLCwsLCwsLCwsL"
+	  " CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsL"
 	  " CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsL",
 	}
 };

--- a/tests/test-autocrypt.c
+++ b/tests/test-autocrypt.c
@@ -157,10 +157,18 @@ struct _ah_parse_test {
 struct _ah_inject_test {
 	const char *name;
 	const struct _ah_gen_test *acheader;
+	const struct _ah_gen_test **gossipheaders;
+	const char **encrypt_to;
 	const char *before;
 	const char *after;
+	const char *inner_after;
 };
 
+const char * local_recipients[] =
+	{
+		"0x0D211DC5D9F4567271AC0582D8DECFBFC9346CD4",
+		NULL,
+	};
 
 const static struct _ah_gen_test alice_addr =
 	{ .addr = "alice@example.org",
@@ -226,6 +234,29 @@ const static struct _ah_inject_test inject_test_data[] = {
 	  "Autocrypt: addr=alice@example.org; keydata=CwsLCwsLCwsLCwsLCwsLCwsLCwsL\n"
 	  " CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsL\n"
 	  " CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsL\n"
+	  "\n"
+	  "Isn't it a lovely day?\n",
+	},
+	{ .name = "gossip injection",
+	  .acheader = &alice_addr,
+	  .gossipheaders = bob_and_carol,
+	  .encrypt_to = local_recipients,
+	  .before = "From: alice@example.org\r\n"
+	  "To: bob@example.org\r\n"
+	  "Subject: A lovely day\r\n"
+	  "Message-Id: <lovely-day@example.net>\r\n"
+	  "Date: Mon, 23 Oct 2017 11:54:14 -0400\r\n"
+	  "Mime-Version: 1.0\r\n"
+	  "Content-Type: text/plain\r\n"
+	  "\r\n"
+	  "Isn't it a lovely day?\r\n",
+	  .inner_after = "Content-Type: text/plain\n"
+	  "Autocrypt-Gossip: addr=bob@example.org; keydata=W1tbW1tbW1tbW1tbW1tbW1tbW1tb\n"
+	  " W1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tb\n"
+	  " W1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tb\n"
+	  "Autocrypt-Gossip: addr=carol@example.org; keydata=WVlZWVlZWVlZWVlZWVlZWVlZWVlZ\n"
+	  " WVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZ\n"
+	  " WVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZ\n"
 	  "\n"
 	  "Isn't it a lovely day?\n",
 	},
@@ -656,6 +687,14 @@ test_ah_injection (void)
 		GMimeMessage *before = NULL;
 		GMimeStream *afterstream = NULL;
 		GByteArray *after = NULL;
+		GMimeAutocryptHeaderList *ahl = NULL;
+		GMimeCryptoContext *ctx = NULL;
+		GPtrArray *recip = NULL;
+		GMimeMultipartEncrypted *encrypted = NULL;
+		GMimeObject *cleartext = NULL;
+		GMimeStream *innerafterstream = NULL;
+		GByteArray *innerafter = NULL;
+		GError *err = NULL;
 		try {
 			const struct _ah_inject_test *test = inject_test_data + i;
 			testsuite_check ("Autocrypt injection[%u] (%s)", i, test->name);
@@ -664,18 +703,68 @@ test_ah_injection (void)
 			parser = g_mime_parser_new_with_stream (stream);
 			before = g_mime_parser_construct_message (parser, NULL);
 
-			ah = _gen_header (test->acheader);
-			g_mime_message_add_autocrypt_header (before, ah);
+			if (test->acheader) {
+				ah = _gen_header (test->acheader);
+				g_mime_message_add_autocrypt_header (before, ah);
+			}
 
-			afterstream = g_mime_stream_mem_new ();
-			g_mime_object_write_to_stream (GMIME_OBJECT (before), NULL, afterstream);
+			if (test->encrypt_to) {
+				ctx = g_mime_gpg_context_new ();
+				recip = g_ptr_array_new ();
+				for (int r = 0; test->encrypt_to[r]; r++)
+					g_ptr_array_add (recip, (gpointer)(test->encrypt_to[r]));
+				/* get_mime_part is "transfer none" so mainpart does not need to be cleaned up */
+				GMimeObject *mainpart = g_mime_message_get_mime_part (before);
+				if (!mainpart) {
+					throw (exception_new ("failed to find main part!\n"));
+				}
+				if (test->gossipheaders) {
+					ahl = _gen_header_list (test->gossipheaders);
+					g_mime_object_add_autocrypt_gossip_headers (mainpart, ahl);
+				}
+				
+				encrypted = g_mime_multipart_encrypted_encrypt (ctx, mainpart, TRUE, NULL,
+										GMIME_ENCRYPT_ALWAYS_TRUST,
+										recip, &err);
+				if (!encrypted) {
+					throw (exception_new ("failed to encrypt: %s", err->message));
+				}
+				g_mime_message_set_mime_part (before, GMIME_OBJECT (encrypted));
+			}
 
-			after = g_mime_stream_mem_get_byte_array (GMIME_STREAM_MEM (afterstream));
+			if (test->after) {
+				afterstream = g_mime_stream_mem_new ();
+				g_mime_object_write_to_stream (GMIME_OBJECT (before), NULL, afterstream);
 
-			gchar *got = (gchar*)after->data;
-			if (memcmp (got, test->after, strlen(test->after))) {
-				fprintf (stderr, "Expected: %s\nGot: %s\n", test->after, got);
-				throw (exception_new ("failed to match"));
+				after = g_mime_stream_mem_get_byte_array (GMIME_STREAM_MEM (afterstream));
+				
+				gchar *got = (gchar*)after->data;
+				if (memcmp (got, test->after, strlen(test->after))) {
+					fprintf (stderr, "Expected: %s\nGot: %s\n", test->after, got);
+					throw (exception_new ("failed to match"));
+				}
+			}
+			if (test->inner_after) {
+				if (!encrypted) {
+					throw (exception_new ("inner_after, but no encrypted part!\n"));
+				}
+				
+				cleartext = g_mime_multipart_encrypted_decrypt (encrypted,
+										GMIME_DECRYPT_NONE,
+										NULL, NULL, &err);
+				if (!cleartext) {
+					throw (exception_new ("decryption failed: %s!\n", err->message));
+				}
+				innerafterstream = g_mime_stream_mem_new ();
+				g_mime_object_write_to_stream (cleartext, NULL, innerafterstream);
+
+				innerafter = g_mime_stream_mem_get_byte_array (GMIME_STREAM_MEM (innerafterstream));
+				
+				gchar *got = (gchar*)innerafter->data;
+				if (memcmp (got, test->inner_after, strlen(test->inner_after))) {
+					fprintf (stderr, "Expected: %s\nGot: %s\n", test->inner_after, got);
+					throw (exception_new ("failed to match"));
+				}
 			}
 			testsuite_check_passed ();
 		} catch (ex) {
@@ -693,6 +782,22 @@ test_ah_injection (void)
 			g_object_unref (afterstream);
 		if (after)
 			g_byte_array_unref (after);
+		if (ahl)
+			g_object_unref (ahl);
+		if (ctx)
+			g_object_unref (ctx);
+		if (recip)
+			g_ptr_array_unref (recip);
+		if (encrypted)
+			g_object_unref (encrypted);
+		if (cleartext)
+			g_object_unref (cleartext);
+		if (err)
+			g_error_free (err);
+		if (innerafterstream)
+			g_object_unref (innerafterstream);
+		if (innerafter)
+			g_byte_array_unref (innerafter);
 		g_free (str);
 		str = NULL;
 	}
@@ -820,7 +925,7 @@ test_ah_message_parse (void)
 static void
 import_secret_key (void)
 {
-	/* generated with GnuPG via:
+	/* generated key 0x0D211DC5D9F4567271AC0582D8DECFBFC9346CD4 with GnuPG via:
 	 *
 	 * export GNUPGHOME=$(mktemp -d)
 	 * gpg --pinentry-mode loopback --passphrase '' --batch --quick-gen-key $(uuidgen)@autocrypt.org

--- a/tests/test-autocrypt.c
+++ b/tests/test-autocrypt.c
@@ -153,6 +153,15 @@ struct _ah_parse_test {
 	const char *innerpart;
 };
 
+
+struct _ah_inject_test {
+	const char *name;
+	const struct _ah_gen_test *acheader;
+	const char *before;
+	const char *after;
+};
+
+
 const static struct _ah_gen_test alice_addr =
 	{ .addr = "alice@example.org",
 	  .keydatacount = 102,
@@ -193,6 +202,33 @@ const static struct _ah_gen_test *bob_and_carol[] = {
 	&bob_addr,
 	&carol_addr,
 	NULL,
+};
+
+const static struct _ah_inject_test inject_test_data[] = {
+	{ .name = "simple",
+	  .acheader = &alice_addr,
+	  .before = "From: alice@example.org\r\n"
+	  "To: bob@example.org\r\n"
+	  "Subject: A lovely day\r\n"
+	  "Message-Id: <lovely-day@example.net>\r\n"
+	  "Date: Mon, 23 Oct 2017 11:54:14 -0400\r\n"
+	  "Mime-Version: 1.0\r\n"
+	  "Content-Type: text/plain\r\n"
+	  "\r\n"
+	  "Isn't it a lovely day?\r\n",
+	  .after = "From: alice@example.org\n"
+	  "To: bob@example.org\n"
+	  "Subject: A lovely day\n"
+	  "Message-Id: <lovely-day@example.net>\n"
+	  "Date: Mon, 23 Oct 2017 11:54:14 -0400\n"
+	  "Mime-Version: 1.0\n"
+	  "Content-Type: text/plain\n"
+	  "Autocrypt: addr=alice@example.org; keydata=CwsLCwsLCwsLCwsLCwsLCwsLCwsL\n"
+	  " CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsL\n"
+	  " CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsL\n"
+	  "\n"
+	  "Isn't it a lovely day?\n",
+	},
 };
 
 const static struct _ah_parse_test parse_test_data[] = {
@@ -606,6 +642,63 @@ const static struct _ah_parse_test parse_test_data[] = {
 };
 
 
+
+
+static void
+test_ah_injection (void)
+{
+	unsigned int i;
+	for (i = 0; i < G_N_ELEMENTS(inject_test_data); i++) {
+		GMimeAutocryptHeader *ah = NULL;
+		char *str = NULL;
+		GMimeStream *stream = NULL;
+		GMimeParser *parser = NULL;
+		GMimeMessage *before = NULL;
+		GMimeStream *afterstream = NULL;
+		GByteArray *after = NULL;
+		try {
+			const struct _ah_inject_test *test = inject_test_data + i;
+			testsuite_check ("Autocrypt injection[%u] (%s)", i, test->name);
+
+			stream = g_mime_stream_mem_new_with_buffer (test->before, strlen(test->before));
+			parser = g_mime_parser_new_with_stream (stream);
+			before = g_mime_parser_construct_message (parser, NULL);
+
+			ah = _gen_header (test->acheader);
+			g_mime_message_add_autocrypt_header (before, ah);
+
+			afterstream = g_mime_stream_mem_new ();
+			g_mime_object_write_to_stream (GMIME_OBJECT (before), NULL, afterstream);
+
+			after = g_mime_stream_mem_get_byte_array (GMIME_STREAM_MEM (afterstream));
+
+			gchar *got = (gchar*)after->data;
+			if (memcmp (got, test->after, strlen(test->after))) {
+				fprintf (stderr, "Expected: %s\nGot: %s\n", test->after, got);
+				throw (exception_new ("failed to match"));
+			}
+			testsuite_check_passed ();
+		} catch (ex) {
+			testsuite_check_failed ("autocrypt header injection failed: %s", ex->message);
+		} finally;
+		if (ah)
+			g_object_unref (ah);
+		if (stream)
+			g_object_unref (stream);
+		if (parser)
+			g_object_unref (parser);
+		if (before)
+			g_object_unref (before);
+		if (afterstream)
+			g_object_unref (afterstream);
+		if (after)
+			g_byte_array_unref (after);
+		g_free (str);
+		str = NULL;
+	}
+}
+
+
 /* returns a non-NULL error if they're not the same */
 char *
 _acheaderlists_compare (GMimeAutocryptHeaderList *expected, GMimeAutocryptHeaderList *got)
@@ -867,6 +960,10 @@ int main (int argc, char **argv)
 	test_ah_message_parse ();
 	testsuite_end ();
 	
+	testsuite_start ("Autocrypt: inject headers");
+	test_ah_injection ();
+	testsuite_end ();
+
 	g_mime_shutdown ();
 	
 #ifdef ENABLE_CRYPTO


### PR DESCRIPTION
This series makes it easy to inject `Autocrypt:` and `Autocrypt-Gossip:` headers in messages being constructed.

The functions themselves are pretty simple, and bulk of the changes are additions to the test suite.