### PR TITLE
fix compiler warnings when building without gpgme support

### DIFF
--- a/gmime/gmime-gpg-context.c
+++ b/gmime/gmime-gpg-context.c
@@ -169,9 +169,9 @@ g_mime_gpg_context_init (GMimeGpgContext *gpg, GMimeGpgContextClass *klass)
 static void
 g_mime_gpg_context_finalize (GObject *object)
 {
+#ifdef ENABLE_CRYPTO
 	GMimeGpgContext *gpg = (GMimeGpgContext *) object;
 	
-#ifdef ENABLE_CRYPTO
 	if (gpg->ctx)
 		gpgme_release (gpg->ctx);
 #endif

--- a/gmime/gmime-pkcs7-context.c
+++ b/gmime/gmime-pkcs7-context.c
@@ -168,9 +168,9 @@ g_mime_pkcs7_context_init (GMimePkcs7Context *pkcs7, GMimePkcs7ContextClass *kla
 static void
 g_mime_pkcs7_context_finalize (GObject *object)
 {
+#ifdef ENABLE_CRYPTO
 	GMimePkcs7Context *pkcs7 = (GMimePkcs7Context *) object;
 	
-#ifdef ENABLE_CRYPTO
 	if (pkcs7->ctx)
 		gpgme_release (pkcs7->ctx);
 #endif

--- a/tests/test-autocrypt.c
+++ b/tests/test-autocrypt.c
@@ -928,6 +928,7 @@ test_ah_message_parse (void)
 }
 
 
+#ifdef ENABLE_CRYPTO
 static void
 import_secret_key (void)
 {
@@ -1041,6 +1042,7 @@ import_secret_key (void)
 	}
 	testsuite_check_passed ();
 }
+#endif
 
 int main (int argc, char **argv)
 {


### PR DESCRIPTION
This trivial patch fixes compiler warnings when building without GpgME crypto support (“configure --disable-crypto”).