### PR TITLE
Make the function for unfolding a header (RFC 5322, sect. 2.2.3) publicly available

### DIFF
--- a/gmime/gmime-header.c
+++ b/gmime/gmime-header.c
@@ -214,37 +214,6 @@ g_mime_header_get_name (GMimeHeader *header)
 }
 
 
-static char *
-unfold (const char *value)
-{
-	register const char *inptr = value;
-	const char *start, *inend;
-	char *str, *outptr;
-	
-	while (is_lwsp (*inptr))
-		inptr++;
-	
-	inend = start = inptr;
-	while (*inptr) {
-		if (!is_lwsp (*inptr++))
-			inend = inptr;
-	}
-	
-	outptr = str = g_malloc ((size_t) (inend - start) + 1);
-	inptr = start;
-	
-	while (inptr < inend) {
-		if (*inptr != '\r' && *inptr != '\n')
-			*outptr++ = *inptr;
-		inptr++;
-	}
-	
-	*outptr = '\0';
-	
-	return str;
-}
-
-
 /**
  * g_mime_header_get_value:
  * @header: a #GMimeHeader
@@ -261,7 +230,7 @@ g_mime_header_get_value (GMimeHeader *header)
 	g_return_val_if_fail (GMIME_IS_HEADER (header), NULL);
 	
 	if (!header->value && header->raw_value) {
-		buf = unfold (header->raw_value);
+		buf = g_mime_utils_header_value_unfold (header->raw_value);
 		header->value = g_mime_utils_header_decode_text (header->options, buf);
 		g_free (buf);
 	}

--- a/gmime/gmime-utils.c
+++ b/gmime/gmime-utils.c
@@ -2754,3 +2754,42 @@ g_mime_utils_header_printf (GMimeParserOptions *options, GMimeFormatOptions *for
 	
 	return ret;
 }
+
+
+/**
+ * g_mime_utils_header_value_unfold:
+ * @value: raw header value
+ *
+ * Unfolds a raw header value according to the rules in rfc822.
+ *
+ * Returns: an allocated string containing the unfolded header value.
+ **/
+char *
+g_mime_utils_header_value_unfold (const char *value)
+{
+	register const char *inptr = value;
+	const char *start, *inend;
+	char *str, *outptr;
+
+	while (is_lwsp (*inptr))
+		inptr++;
+
+	inend = start = inptr;
+	while (*inptr) {
+		if (!is_lwsp (*inptr++))
+			inend = inptr;
+	}
+
+	outptr = str = g_malloc ((size_t) (inend - start) + 1);
+	inptr = start;
+
+	while (inptr < inend) {
+		if (*inptr != '\r' && *inptr != '\n')
+			*outptr++ = *inptr;
+		inptr++;
+	}
+
+	*outptr = '\0';
+
+	return str;
+}

--- a/gmime/gmime-utils.h
+++ b/gmime/gmime-utils.h
@@ -42,6 +42,7 @@ char *g_mime_utils_decode_message_id (const char *message_id);
 char  *g_mime_utils_structured_header_fold (GMimeParserOptions *options, GMimeFormatOptions *format, const char *header);
 char  *g_mime_utils_unstructured_header_fold (GMimeParserOptions *options, GMimeFormatOptions *format, const char *header);
 char  *g_mime_utils_header_printf (GMimeParserOptions *options, GMimeFormatOptions *format, const char *text, ...) G_GNUC_PRINTF (3, 4);
+char  *g_mime_utils_header_value_unfold (const char *value);
 
 char  *g_mime_utils_quote_string (const char *str);
 void   g_mime_utils_unquote_string (char *str);


### PR DESCRIPTION
Rationale: GMime 2.6 functions like g_mime_header_iter_get_value() returned the unfolded, RFC 2047 encoded value.  GMime 3 has only functions for reading the raw, folded (g_mime_header_get_raw_value) or the completely processed (unfolded, decoded) value (g_mime_header_get_value).  Using the g_mime_utils_header_value_unfold() function, applied to the raw value, it is easier to migrate old GMime 2.6 code which needs the unfolded, but still encoded headers to GMime 3.

The patch simply shifts the function unfold() from gmime/gmime-header.c to gmime/gmime-utils.c and renames it to g_mime_utils_header_value_unfold().