### PR TITLE
Improve parser issue detection

### DIFF
--- a/examples/msgcheck.c
+++ b/examples/msgcheck.c
@@ -34,24 +34,26 @@ static const gchar *
 errcode2str(GMimeParserWarning errcode)
 {
 	switch (errcode) {
-	case GMIME_WARN_DUPLICATED_CONTENT_HDR:
-		return "duplicated content header";
+	case GMIME_WARN_DUPLICATED_HEADER:
+		return "duplicated header";
 	case GMIME_WARN_DUPLICATED_PARAMETER:
 		return "duplicated header parameter";
 	case GMIME_WARN_UNENCODED_8BIT_HEADER:
 		return "unencoded 8-bit characters in header";
 	case GMIME_WARN_INVALID_CONTENT_TYPE:
 		return "invalid Content-Type";
-	case GMIME_WARN_INVALID_HEADER:
-		return "invalid header";
+	case GMIME_WARN_INVALID_RFC2047_HEADER_VALUE:
+		return "invalid RFC 2047 encoded header value";
 	case GMIME_WARN_MALFORMED_MULTIPART:
 		return "malformed multipart";
 	case GMIME_WARN_TRUNCATED_MESSAGE:
 		return "truncated message";
 	case GMIME_WARN_MALFORMED_MESSAGE:
 		return "malformed message";
-	case GMIME_CRIT_CONFLICTING_CONTENT_HDR:
-		return "conflicting content header";
+	case GMIME_CRIT_INVALID_HEADER_NAME:
+		return "invalid header name, parser may skip the message or parts of it";
+	case GMIME_CRIT_CONFLICTING_HEADER:
+		return "conflicting duplicated header";
 	case GMIME_CRIT_CONFLICTING_PARAMETER:
 		return "conflicting header parameter";
 	case GMIME_CRIT_MULTIPART_WITHOUT_BOUNDARY:

--- a/gmime/gmime-header.c
+++ b/gmime/gmime-header.c
@@ -231,7 +231,7 @@ g_mime_header_get_value (GMimeHeader *header)
 	
 	if (!header->value && header->raw_value) {
 		buf = g_mime_utils_header_unfold (header->raw_value);
-		header->value = g_mime_utils_header_decode_text (header->options, buf);
+		header->value = _g_mime_utils_header_decode_text (header->options, buf, NULL, header->offset);
 		g_free (buf);
 	}
 	
@@ -602,7 +602,7 @@ g_mime_header_format_addrlist (GMimeHeader *header, GMimeFormatOptions *options,
 	
 	g_string_append_c (str, ' ');
 	
-	if (value && (addrlist = internet_address_list_parse (header->options, value))) {
+	if (value && (addrlist = _internet_address_list_parse (header->options, value, -1))) {
 		internet_address_list_encode (addrlist, options, str);
 		g_object_unref (addrlist);
 	}

--- a/gmime/gmime-internal.h
+++ b/gmime/gmime-internal.h
@@ -86,8 +86,13 @@ G_GNUC_INTERNAL char *_g_mime_utils_unstructured_header_fold (GMimeParserOptions
 							      const char *field, const char *value);
 G_GNUC_INTERNAL char *_g_mime_utils_structured_header_fold (GMimeParserOptions *options, GMimeFormatOptions *format,
 							    const char *field, const char *value);
-G_GNUC_INTERNAL char *_g_mime_utils_header_decode_text (GMimeParserOptions *options, const char *text, const char **charset);
-G_GNUC_INTERNAL char *_g_mime_utils_header_decode_phrase (GMimeParserOptions *options, const char *text, const char **charset);
+G_GNUC_INTERNAL char *_g_mime_utils_header_decode_text (GMimeParserOptions *options, const char *text, const char **charset,
+							gint64 offset);
+G_GNUC_INTERNAL char *_g_mime_utils_header_decode_phrase (GMimeParserOptions *options, const char *text, const char **charset,
+							  gint64 offset);
+
+/* InternetAddressList */
+G_GNUC_INTERNAL InternetAddressList *_internet_address_list_parse (GMimeParserOptions *options, const char *str, gint64 offset);
 
 G_END_DECLS
 

--- a/gmime/gmime-message.c
+++ b/gmime/gmime-message.c
@@ -284,7 +284,7 @@ message_update_addresses (GMimeMessage *message, GMimeParserOptions *options, GM
 			continue;
 		
 		if ((value = g_mime_header_get_raw_value (header))) {
-			if ((list = internet_address_list_parse (options, value))) {
+			if ((list = _internet_address_list_parse (options, value, header->offset))) {
 				internet_address_list_append (addrlist, list);
 				g_object_unref (list);
 			}

--- a/gmime/gmime-param.c
+++ b/gmime/gmime-param.c
@@ -1055,7 +1055,7 @@ decode_rfc2184_param (const char **in, char **namep, int *part, gboolean *encode
 
 static gboolean
 decode_param (GMimeParserOptions *options, const char **in, char **namep, char **valuep, int *id,
-	      const char **rfc2047_charset, gboolean *encoded, GMimeParamEncodingMethod *method)
+	      const char **rfc2047_charset, gboolean *encoded, GMimeParamEncodingMethod *method, gint64 offset)
 {
 	GMimeRfcComplianceMode mode = g_mime_parser_options_get_parameter_compliance_mode (options);
 	gboolean is_rfc2184 = FALSE;
@@ -1080,7 +1080,7 @@ decode_param (GMimeParserOptions *options, const char **in, char **namep, char *
 				 * this, we should handle this case.
 				 */
 				
-				if ((val = _g_mime_utils_header_decode_text (options, value, rfc2047_charset))) {
+				if ((val = _g_mime_utils_header_decode_text (options, value, rfc2047_charset, offset))) {
 					*method = GMIME_PARAM_ENCODING_METHOD_RFC2047;
 					g_free (value);
 					value = val;
@@ -1338,7 +1338,7 @@ decode_param_list (GMimeParserOptions *options, const char *in, gint64 offset)
 	
 	do {
 		/* invalid format? */
-		if (!decode_param (options, &inptr, &name, &value, &id, &rfc2047_charset, &encoded, &method)) {
+		if (!decode_param (options, &inptr, &name, &value, &id, &rfc2047_charset, &encoded, &method, offset)) {
 			skip_cfws (&inptr);
 			
 			if (*inptr == ';')

--- a/gmime/gmime-parser-options.h
+++ b/gmime/gmime-parser-options.h
@@ -43,15 +43,16 @@ typedef enum {
 
 /**
  * GMimeParserWarning:
- * @GMIME_WARN_DUPLICATED_CONTENT_HDR: repeated exactly the same `Content-*` header
+ * @GMIME_WARN_DUPLICATED_HEADER: repeated exactly the same header which should exist only once
  * @GMIME_WARN_DUPLICATED_PARAMETER: repeated exactly the same header parameter
  * @GMIME_WARN_UNENCODED_8BIT_HEADER: a header contains unencoded 8-bit characters
  * @GMIME_WARN_INVALID_CONTENT_TYPE: invalid content type, assume `application/octet-stream`
- * @GMIME_WARN_INVALID_HEADER: invalid header, ignored
+ * @GMIME_WARN_INVALID_RFC2047_HEADER_VALUE: invalid RFC 2047 encoded header value
  * @GMIME_WARN_MALFORMED_MULTIPART: no items in a `multipart/...`
  * @GMIME_WARN_TRUNCATED_MESSAGE: the message is truncated
  * @GMIME_WARN_MALFORMED_MESSAGE: the message is malformed
- * @GMIME_CRIT_CONFLICTING_CONTENT_HDR: conflicting `Content-*` header
+ * @GMIME_CRIT_INVALID_HEADER_NAME: invalid header name, the parser may skip the message or parts of it
+ * @GMIME_CRIT_CONFLICTING_HEADER: conflicting header
  * @GMIME_CRIT_CONFLICTING_PARAMETER: conflicting header parameter
  * @GMIME_CRIT_MULTIPART_WITHOUT_BOUNDARY: a `multipart/...` part lacks the required boundary parameter
  *
@@ -59,15 +60,16 @@ typedef enum {
  * be ignored or will be interpreted differently by other software products.
  **/
 typedef enum {
-	GMIME_WARN_DUPLICATED_CONTENT_HDR = 1U,
+	GMIME_WARN_DUPLICATED_HEADER = 1U,
 	GMIME_WARN_DUPLICATED_PARAMETER,
 	GMIME_WARN_UNENCODED_8BIT_HEADER,
 	GMIME_WARN_INVALID_CONTENT_TYPE,
-	GMIME_WARN_INVALID_HEADER,
+	GMIME_WARN_INVALID_RFC2047_HEADER_VALUE,
 	GMIME_WARN_MALFORMED_MULTIPART,
 	GMIME_WARN_TRUNCATED_MESSAGE,
 	GMIME_WARN_MALFORMED_MESSAGE,
-	GMIME_CRIT_CONFLICTING_CONTENT_HDR,
+	GMIME_CRIT_INVALID_HEADER_NAME,
+	GMIME_CRIT_CONFLICTING_HEADER,
 	GMIME_CRIT_CONFLICTING_PARAMETER,
 	GMIME_CRIT_MULTIPART_WITHOUT_BOUNDARY
 } GMimeParserWarning;


### PR DESCRIPTION
This patch aims at improving the detection of issues in the GMime parser:

(1) Illegal header values
Catch more cases where the parser detects a malformed header name, and always report it as critical issue as the parser may skip the entire message or parts of it.

(2) Detect more duplicated headers
Detect duplicated headers which may exist only once according to RFC 5322, Sect. 3.6.  Whilst a repetition of the same value can be used as spam indicator, a different value could be used to break DKIM signatures (see <http://noxxi.de/research/breaking-dkim-on-purpose-and-by-chance.html#hdr2>).

(3) Report RFC 2047 violation
A space is not allowed within a RFC 2047 encoded-word and may be a spam indicator.

Note that some parser warning codes have been renamed as to describe their purpose clearer.

Details:
========
* gmime/gmime-internal.h: add offset parameter to _g_mime_utils_header_decode_(text|phrase); new function _internet_address_list_parse
* gmime/gmime-header.c, gmime/gmime-message.c: use modified/new internal functions
* gmime/gmime-param.c: pass offset to decode_param
* gmime/gmime-parser-options.h: rename some warning codes, broken header name is always critical, add RFC 2047 error
* gmime/gmime-parser.c: replace is_7bit_clean by the functionally equivalent g_mime_utils_text_is_8bit; always warn about broken header name; refactor and add code for detecting more duplicated headers; properly set parser options when scanning an embedded message part
* gmime/gmime-utils.c: detect SP in RFC 2047 encoded-word; pass offset to _g_mime_utils_header_decode_(text|phrase)
* gmime/internet-address.c: pass offset to decode_name, address_list_parse, group_parse, address_parse; add new function _internet_address_list_parse with an additional offset parameter, and make internet_address_list_parse a wrapper for it
* examples/msgcheck.c: use new warning codes in the example application
