### PR TITLE
Report invalid message header parameters

### DIFF
--- a/examples/msgcheck.c
+++ b/examples/msgcheck.c
@@ -44,6 +44,8 @@ errcode2str(GMimeParserWarning errcode)
 		return "invalid Content-Type";
 	case GMIME_WARN_INVALID_RFC2047_HEADER_VALUE:
 		return "invalid RFC 2047 encoded header value";
+	case GMIME_WARN_INVALID_PARAMETER:
+		return "invalid header parameter";
 	case GMIME_WARN_MALFORMED_MULTIPART:
 		return "malformed multipart";
 	case GMIME_WARN_TRUNCATED_MESSAGE:

--- a/gmime/gmime-param.c
+++ b/gmime/gmime-param.c
@@ -1108,7 +1108,8 @@ decode_param (GMimeParserOptions *options, const char **in, char **namep, char *
 		*namep = name;
 		*in = inptr;
 		return TRUE;
-	}
+	} else
+		_g_mime_parser_options_warn (options, offset, GMIME_WARN_INVALID_PARAMETER, name);
 	
 	g_free (value);
 	g_free (name);

--- a/gmime/gmime-parser-options.h
+++ b/gmime/gmime-parser-options.h
@@ -48,6 +48,7 @@ typedef enum {
  * @GMIME_WARN_UNENCODED_8BIT_HEADER: a header contains unencoded 8-bit characters
  * @GMIME_WARN_INVALID_CONTENT_TYPE: invalid content type, assume `application/octet-stream`
  * @GMIME_WARN_INVALID_RFC2047_HEADER_VALUE: invalid RFC 2047 encoded header value
+ * @GMIME_WARN_INVALID_PARAMETER: invalid header parameter
  * @GMIME_WARN_MALFORMED_MULTIPART: no items in a `multipart/...`
  * @GMIME_WARN_TRUNCATED_MESSAGE: the message is truncated
  * @GMIME_WARN_MALFORMED_MESSAGE: the message is malformed
@@ -65,6 +66,7 @@ typedef enum {
 	GMIME_WARN_UNENCODED_8BIT_HEADER,
 	GMIME_WARN_INVALID_CONTENT_TYPE,
 	GMIME_WARN_INVALID_RFC2047_HEADER_VALUE,
+	GMIME_WARN_INVALID_PARAMETER,
 	GMIME_WARN_MALFORMED_MULTIPART,
 	GMIME_WARN_TRUNCATED_MESSAGE,
 	GMIME_WARN_MALFORMED_MESSAGE,


### PR DESCRIPTION
The warning is triggered when a parameter value is missing, the parameter name or value are malformed, or the parameter list ends with a ';'.  This is typically not critical, but may indicate a spam message.

I am not aware of any RFC which allows either an empty value or the list ending in ';' (e.g. RFC 2046 and RFC 2183 explicitly forbid it).  Recently, I received a bunch of (mal-) spam messages with a broken `Content-Type: text/plain; charset=` header which is detected properly with this patch.