### PR TITLE
Enable RFC 2047 compliance check for all headers

### DIFF
--- a/gmime/gmime-object.c
+++ b/gmime/gmime-object.c
@@ -195,12 +195,17 @@ static void
 object_header_changed (GMimeObject *object, GMimeHeader *header)
 {
 	GMimeParserOptions *options = _g_mime_header_list_get_options (object->headers);
+	gboolean can_warn = g_mime_parser_options_get_warning_callback (options) != NULL;
 	GMimeContentDisposition *disposition;
 	GMimeContentType *content_type;
 	const char *name, *value;
 	guint i;
 	
 	name = g_mime_header_get_name (header);
+
+	/* validate header if requested, caches the decoded value */
+	if (G_UNLIKELY (can_warn))
+		g_mime_header_get_value (header);
 	
 	if (g_ascii_strncasecmp (name, "Content-", 8) != 0)
 		return;


### PR DESCRIPTION
This simple patch enables the parser check for RFC 2047 violations in all message headers.

The performance impact if no parser error reporting is enabled (i.e. the callback is NULL) should be negligible. In the case of error reporting, decoding and caching all headers will slightly increase the memory and time consumption.