### PR TITLE
Report violations of RFC 5322 address specifications

### DIFF
--- a/examples/msgcheck.c
+++ b/examples/msgcheck.c
@@ -52,6 +52,8 @@ errcode2str(GMimeParserWarning errcode)
 		return "truncated message";
 	case GMIME_WARN_MALFORMED_MESSAGE:
 		return "malformed message";
+	case GMIME_WARN_INVALID_ADDRESS_SPEC:
+		return "invalid address specification";
 	case GMIME_CRIT_INVALID_HEADER_NAME:
 		return "invalid header name, parser may skip the message or parts of it";
 	case GMIME_CRIT_CONFLICTING_HEADER:

--- a/gmime/gmime-parser-options.h
+++ b/gmime/gmime-parser-options.h
@@ -52,6 +52,7 @@ typedef enum {
  * @GMIME_WARN_MALFORMED_MULTIPART: no items in a `multipart/...`
  * @GMIME_WARN_TRUNCATED_MESSAGE: the message is truncated
  * @GMIME_WARN_MALFORMED_MESSAGE: the message is malformed
+ * @GMIME_WARN_INVALID_ADDRESS_SPEC: invalid address specification
  * @GMIME_CRIT_INVALID_HEADER_NAME: invalid header name, the parser may skip the message or parts of it
  * @GMIME_CRIT_CONFLICTING_HEADER: conflicting header
  * @GMIME_CRIT_CONFLICTING_PARAMETER: conflicting header parameter
@@ -73,7 +74,8 @@ typedef enum {
 	GMIME_CRIT_CONFLICTING_HEADER,
 	GMIME_CRIT_CONFLICTING_PARAMETER,
 	GMIME_CRIT_MULTIPART_WITHOUT_BOUNDARY,
-	GMIME_WARN_INVALID_PARAMETER
+	GMIME_WARN_INVALID_PARAMETER,
+	GMIME_WARN_INVALID_ADDRESS_SPEC
 } GMimeParserWarning;
 
 /**


### PR DESCRIPTION
Use the GMimeParserWarning facility to report a warning if
(1) parsing an address failed with any error or
(2) multiple adresses in a mailbox-list are not separated properly.

Note that violations of the latter were used in recent malspam campaigns which typically contain a header
`From: Spoofed Sender <spoofed.sender@legitimate.com> <hacked.sender@other.com>`
where some MUA's will display _only_ `Spoofed Sender <spoofed.sender@legitimate.com>` as (allegedly legitimate, well-known) sender.

Currently, GMime extracts the two addresses from this header, without giving a warning.  With the patch, both addresses are still extracted, but the RFC violation can be reported.  IMO it should not be considered as critical issue without further inspection (thus a WARN code) as I saw examples coming from web mailers showing this issue for otherwise completely sane messages.

I'm not sure if there would be a nicer approach to detect these issues, but it works fine for me, even if the header contains a mixture of group and mailbox addresses.