### PR TITLE
Expose signature creation time and expiration time as guint64

### DIFF
--- a/gmime/gmime-signature.c
+++ b/gmime/gmime-signature.c
@@ -257,6 +257,49 @@ g_mime_signature_get_expires (GMimeSignature *sig)
 }
 
 
+/**
+ * g_mime_signature_get_created_usecs:
+ * @sig: a #GMimeSignature
+ * @created: (out) pointer to output creation time [out]
+ *
+ * Get the creation date of the signature in microseconds since the UNIX epoch.
+ *
+ * Returns: TRUE if successful; FALSE if @esig is not a signature, @created is NULL, or there is no known creation date for the signature.
+ **/
+gboolean
+g_mime_signature_get_created_usecs (const GMimeSignature *sig, guint64 *created)
+{
+	g_return_val_if_fail (GMIME_IS_SIGNATURE (sig), FALSE);
+	g_return_val_if_fail (created != NULL, FALSE);
+	g_return_val_if_fail (sig->created != (time_t)-1, FALSE);
+
+	*created = ((guint64)((unsigned long)(sig->created))) * 1000000;
+
+	return TRUE;
+}
+
+/**
+ * g_mime_signature_get_expires_usecs:
+ * @sig: a #GMimeSignature
+ * @expires: (out) pointer to output expiration time [out]
+ *
+ * Get the expiration date of the signature in microseconds since the UNIX epoch.
+ *
+ * Returns: TRUE if successful; FALSE if @esig is not a signature, @expires is NULL, or there is no known expiration date for the signature.
+ **/
+gboolean
+g_mime_signature_get_expires_usecs (const GMimeSignature *sig, guint64 *expires)
+{
+	g_return_val_if_fail (GMIME_IS_SIGNATURE (sig), FALSE);
+	g_return_val_if_fail (expires != NULL, FALSE);
+	g_return_val_if_fail (sig->expires != (time_t)-1, FALSE);
+
+	*expires = ((guint64)((unsigned long)(sig->expires))) * 1000000;
+
+	return TRUE;
+}
+
+
 static void g_mime_signature_list_class_init (GMimeSignatureListClass *klass);
 static void g_mime_signature_list_init (GMimeSignatureList *list, GMimeSignatureListClass *klass);
 static void g_mime_signature_list_finalize (GObject *object);

--- a/gmime/gmime-signature.h
+++ b/gmime/gmime-signature.h
@@ -131,6 +131,8 @@ time_t g_mime_signature_get_created (GMimeSignature *sig);
 void g_mime_signature_set_expires (GMimeSignature *sig, time_t expires);
 time_t g_mime_signature_get_expires (GMimeSignature *sig);
 
+gboolean g_mime_signature_get_created_usecs (const GMimeSignature *sig, guint64 *created);
+gboolean g_mime_signature_get_expires_usecs (const GMimeSignature *sig, guint64 *created);
 
 /**
  * GMimeSignatureList:


### PR DESCRIPTION
This is a very conservative change that attempts to address #68.

It avoids changing the memory layout of the GMimeSignature object,
since it might accessed directly by a user who doesn't use the
function interface.

It takes a different approach to indicating a failure than the
established (time_t)-1 mechanism, to encourage safer use.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>