### PR TITLE
Explain units for g_mime_{certificate,signature}_get_{created,expires}64

### DIFF
--- a/gmime/gmime-certificate.c
+++ b/gmime/gmime-certificate.c
@@ -560,7 +560,8 @@ g_mime_certificate_get_created (GMimeCertificate *cert)
  * g_mime_certificate_get_created64:
  * @cert: a #GMimeCertificate
  *
- * Get the creation date of the certificate's key.
+ * Get the creation date of the certificate's key in seconds since the
+ * UNIX epoch, represented as a 64-bit signed integer.
  *
  * Returns: the creation date of the certificate's key or %-1 if unknown.
  **/
@@ -613,7 +614,9 @@ g_mime_certificate_get_expires (GMimeCertificate *cert)
  * g_mime_certificate_get_expires64:
  * @cert: a #GMimeCertificate
  *
- * Get the expiration date of the certificate's key. A value of %0 means the certificate never expires.
+ * Get the expiration date of the certificate's key in seconds since
+ * the UNIX epoch, represented as a 64-bit signed integer. A value of
+ * %0 means the certificate never expires.
  *
  * Returns: the expiration date of the certificate's key or %-1 if unknown.
  **/

--- a/gmime/gmime-signature.c
+++ b/gmime/gmime-signature.c
@@ -228,7 +228,8 @@ g_mime_signature_get_created (GMimeSignature *sig)
  * g_mime_signature_get_created64:
  * @sig: a #GMimeSignature
  *
- * Get the creation date of the signature.
+ * Get the creation date of the signature in seconds since the UNIX
+ * epoch, represented as a 64-bit signed integer.
  *
  * Returns: the creation date of the signature or %-1 if unknown.
  **/
@@ -281,7 +282,9 @@ g_mime_signature_get_expires (GMimeSignature *sig)
  * g_mime_signature_get_expires64:
  * @sig: a #GMimeSignature
  *
- * Get the expiration date of the signature. A value of %0 means the signature never expires.
+ * Get the expiration date of the signature in seconds since the UNIX
+ * epoch, represented as a 64-bit signed integer. A value of %0 means
+ * the signature never expires.
  *
  * Returns: the expiration date of the signature or %-1 if unknown.
  **/


### PR DESCRIPTION
The standard g_mime_{certificate,signature}_get_{created,expires}
functions return a time_t whose units are well-defined by the
operating system.

The new 64-bit accessors provide a gint64, which has no such implicit
definition, so GMime should be explicit about what it intends these
values to represent.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>