### PR TITLE
Fix vala abstract public constructor warning

### DIFF
--- a/gmime/GMime-3.0-custom.vala
+++ b/gmime/GMime-3.0-custom.vala
@@ -1,0 +1,13 @@
+namespace GMime {
+
+    public abstract class Object : GLib.Object {
+        [CCode (cname = "g_mime_object_new")]
+        public static Object new_for_type(GMime.ParserOptions? options,
+                                          GMime.ContentType content_type);
+        [CCode (cname = "g_mime_object_new_type")]
+        public static Object new_for_type_str(GMime.ParserOptions? options,
+                                              string type,
+                                              string subtype);
+    }
+
+}

--- a/gmime/GMime-3.0.metadata
+++ b/gmime/GMime-3.0.metadata
@@ -2,6 +2,11 @@ InternetAddress
   .to_string#method name="to_new_string"
 References struct=false
 
+// These are actually static factory methods
+Object
+  .new skip
+  .new_type skip
+
 // G-I can't handle non-boxed types
 PartIter struct=false
 

--- a/gmime/Makefile.am
+++ b/gmime/Makefile.am
@@ -225,12 +225,12 @@ endif
 if ENABLE_VAPIGEN
 -include $(VAPIGEN_MAKEFILE)
 
-gmime-3.0.vapi: GMime-3.0.gir GMime-3.0.metadata
+gmime-3.0.vapi: GMime-3.0.gir GMime-3.0.metadata GMime-3.0-custom.vala
 
 VAPIGEN_VAPIS = gmime-3.0.vapi
 gmime_3_0_vapi_DEPS = gio-2.0
 gmime_3_0_vapi_METADATADIRS = $(srcdir)
-gmime_3_0_vapi_FILES = GMime-3.0.gir
+gmime_3_0_vapi_FILES = GMime-3.0.gir GMime-3.0-custom.vala
 
 gmime-3.0.deps:
 	$(AM_V_GEN) for pkg in $(gmime_3_0_vapi_DEPS); do \


### PR DESCRIPTION
This fixes "Creation method of abstract class cannot be public" warnings
when compiling with recent valac.

Since `g_mime_object_new[_type]` are effectively static factory methods
rather than constructors, suppress their use as ctors and bind using
custom static methods.