### PR TITLE
Update to MSVC 2017 projects.

### DIFF
--- a/build/Makefile.am
+++ b/build/Makefile.am
@@ -1,3 +1,3 @@
 ## Process this file with automake to produce Makefile.in
 
-SUBDIRS = vs2008 vs2010
+SUBDIRS = vs2008 vs2010 vs2017

--- a/build/vs2017/.gitignore
+++ b/build/vs2017/.gitignore
@@ -1,3 +1,6 @@
+Makefile.in
+Makefile
+
 .vs/
 Debug*/
 Release*/

--- a/build/vs2017/Makefile.am
+++ b/build/vs2017/Makefile.am
@@ -1,0 +1,19 @@
+## Process this file with automake to produce Makefile.in
+
+EXTRA_DIST = \
+	gmime.def			\
+	basic-example.vcxproj.filters	\
+	gmime.vcxproj.filters		\
+	imap-example.vcxproj.filters	\
+	msgcheck.vcxproj.filters	\
+	uudecode.vcxproj.filters	\
+	uuencode.vcxproj.filters	\
+	config.h			\
+	unistd.h			\
+	gmime.sln			\
+	basic-example.vcxproj		\
+	gmime.vcxproj			\
+	imap-example.vcxproj		\
+	msgcheck.vcxproj		\
+	uudecode.vcxproj		\
+	uuencode.vcxproj

--- a/build/vs2017/basic-example.vcxproj
+++ b/build/vs2017/basic-example.vcxproj
@@ -171,7 +171,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -185,7 +184,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -199,7 +197,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -213,7 +210,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -229,7 +225,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -246,7 +241,6 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -265,7 +259,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -282,7 +275,6 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/build/vs2017/gmime.sln
+++ b/build/vs2017/gmime.sln
@@ -13,6 +13,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "basic-example", "basic-exam
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "imap-example", "imap-example.vcxproj", "{F43D5E68-E39F-4C88-B8E6-7401309CC05F}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msgcheck", "msgcheck.vcxproj", "{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug-DLL|x64 = Debug-DLL|x64
@@ -105,6 +107,22 @@ Global
 		{F43D5E68-E39F-4C88-B8E6-7401309CC05F}.Release-Static|x64.Build.0 = Release-Static|x64
 		{F43D5E68-E39F-4C88-B8E6-7401309CC05F}.Release-Static|x86.ActiveCfg = Release-Static|Win32
 		{F43D5E68-E39F-4C88-B8E6-7401309CC05F}.Release-Static|x86.Build.0 = Release-Static|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-DLL|x64.ActiveCfg = Debug-DLL|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-DLL|x64.Build.0 = Debug-DLL|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-DLL|x86.ActiveCfg = Debug-DLL|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-DLL|x86.Build.0 = Debug-DLL|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-Static|x64.ActiveCfg = Debug-Static|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-Static|x64.Build.0 = Debug-Static|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-Static|x86.ActiveCfg = Debug-Static|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Debug-Static|x86.Build.0 = Debug-Static|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-DLL|x64.ActiveCfg = Release-DLL|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-DLL|x64.Build.0 = Release-DLL|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-DLL|x86.ActiveCfg = Release-DLL|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-DLL|x86.Build.0 = Release-DLL|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-Static|x64.ActiveCfg = Release-Static|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-Static|x64.Build.0 = Release-Static|x64
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-Static|x86.ActiveCfg = Release-Static|Win32
+		{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}.Release-Static|x86.Build.0 = Release-Static|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/vs2017/msgcheck.vcxproj
+++ b/build/vs2017/msgcheck.vcxproj
@@ -40,11 +40,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\examples\imap-example.c" />
+    <ClCompile Include="..\..\examples\msgcheck.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{F43D5E68-E39F-4C88-B8E6-7401309CC05F}</ProjectGuid>
+    <ProjectGuid>{4D289FD2-11CD-48DB-AFF3-3A8295A3AB5C}</ProjectGuid>
     <RootNamespace>gmime</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>

--- a/build/vs2017/msgcheck.vcxproj.filters
+++ b/build/vs2017/msgcheck.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\examples\msgcheck.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/build/vs2017/uudecode.vcxproj
+++ b/build/vs2017/uudecode.vcxproj
@@ -171,7 +171,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -185,7 +185,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -199,7 +199,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -213,7 +213,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -229,7 +229,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -246,8 +246,8 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -265,7 +265,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -282,8 +282,8 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/build/vs2017/uuencode.vcxproj
+++ b/build/vs2017/uuencode.vcxproj
@@ -171,7 +171,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -185,7 +184,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -199,7 +197,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -213,7 +210,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -229,7 +225,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -246,7 +241,6 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -265,7 +259,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -282,7 +275,6 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <PreprocessorDefinitions>WIN32;_NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;G_DISABLE_DEPRECATED;G_LOG_DOMAIN="GMime";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4018;4244;4267;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>.;../..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/examples/msgcheck.c
+++ b/examples/msgcheck.c
@@ -19,6 +19,10 @@
  *  Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdlib.h>
 #include <gmime/gmime.h>
 


### PR DESCRIPTION
Minor update to MSVC 2017 projects.
- Added project for 'msgcheck' example program (sorry, missed that one). Added config.h in msgcheck.c be able to build it properly.
- Added Makefile.am file to new directory similar to old MSVC projects. Don't know how it is used but I guess it is better to follow existing rules :).