### PR TITLE
Fix g_mime_content_encoding_to_string return null for …DEFAULT value

### DIFF
--- a/gmime/gmime-encodings.c
+++ b/gmime/gmime-encodings.c
@@ -166,6 +166,8 @@ const char *
 g_mime_content_encoding_to_string (GMimeContentEncoding encoding)
 {
 	switch (encoding) {
+        case GMIME_CONTENT_ENCODING_DEFAULT:
+		return "default";
         case GMIME_CONTENT_ENCODING_7BIT:
 		return "7bit";
         case GMIME_CONTENT_ENCODING_8BIT:


### PR DESCRIPTION
Its API docs say that GMIME_CONTENT_ENCODING_DEFAULT is a valid value,
but that is missed in the switch, resulting in null being returned
when that is passed in.

This also fixes expected behaviour for the Vala bindings, where a
string is returned for any valid enum value.