### PR TITLE
g_mime_gpgme_get_decrypt_result: don't leak cert

### DIFF
--- a/gmime/gmime-gpgme-utils.c
+++ b/gmime/gmime-gpgme-utils.c
@@ -593,6 +593,7 @@ g_mime_gpgme_get_decrypt_result (gpgme_ctx_t ctx)
 		
 		g_mime_certificate_set_pubkey_algo (cert, (GMimePubKeyAlgo) recipient->pubkey_algo);
 		g_mime_certificate_set_key_id (cert, recipient->keyid);
+		g_object_unref(cert);
 		
 		recipient = recipient->next;
 	}


### PR DESCRIPTION
g_mime_certificate_list_add adds a ref, so if we don't unref it, the cert will
never be destroyed.