### PR TITLE
Correct some annotations for gir

### DIFF
--- a/gmime/gmime-crypto-context.c
+++ b/gmime/gmime-crypto-context.c
@@ -563,7 +563,7 @@ crypto_export_keys (GMimeCryptoContext *ctx, const char *keys[],
 /**
  * g_mime_crypto_context_export_keys:
  * @ctx: a #GMimeCryptoContext
- * @keys: an array of key ids, terminated by a %NULL element
+ * @keys: (array zero-terminated=1): an array of key ids, terminated by a %NULL element
  * @ostream: output stream
  * @err: a #GError
  *

--- a/gmime/gmime-filter-checksum.c
+++ b/gmime/gmime-filter-checksum.c
@@ -174,7 +174,7 @@ g_mime_filter_checksum_new (GChecksumType type)
 /**
  * g_mime_filter_checksum_get_digest:
  * @checksum: checksum filter object
- * @digest: the digest buffer
+ * @digest: (array length=len): the digest buffer
  * @len: the length of the digest buffer
  *
  * Outputs the checksum digest into @digest.

--- a/gmime/gmime-message-partial.c
+++ b/gmime/gmime-message-partial.c
@@ -241,7 +241,7 @@ partial_compare (const void *v1, const void *v2)
 
 /**
  * g_mime_message_partial_reconstruct_message:
- * @partials: an array of message/partial mime parts
+ * @partials: (array length=num) (element-type GMimeMessagePartial): an array of message/partial mime parts
  * @num: the number of elements in @partials
  *
  * Reconstructs the GMimeMessage from the given message/partial parts
@@ -359,7 +359,7 @@ message_partial_message_new (GMimeMessage *base)
  * @max_size bytes or fewer. @nparts is set to the number of
  * #GMimeMessagePartial objects created.
  *
- * Returns: (nullable) (transfer full): an array of #GMimeMessage objects and
+ * Returns: (nullable) (transfer full) (array length=nparts): an array of #GMimeMessage objects and
  * sets @nparts to the number of messages returned or %NULL on fail.
  **/
 GMimeMessage **

--- a/gmime/gmime-param.c
+++ b/gmime/gmime-param.c
@@ -720,7 +720,7 @@ g_string_append_len_quoted (GString *str, const char *text, size_t len)
  * @list: a #GMimeParamList
  * @options: a #GMimeFormatOptions or %NULL
  * @fold: %TRUE if the parameter list should be folded; otherwise, %FALSE
- * @str: the output string buffer
+ * @str: (out): the output string buffer
  *
  * Encodes the parameter list into @str, folding lines if required.
  **/


### PR DESCRIPTION
Some of the annotations created gir entries that were impossible (or very awkward) to use in other languages.