### PR TITLE
quote display names with unterminated qstrings when formatting address lists

### DIFF
--- a/gmime/gmime-utils.c
+++ b/gmime/gmime-utils.c
@@ -948,7 +948,7 @@ need_quotes (const char *string)
 			inptr++;
 	}
 	
-	return FALSE;
+	return quoted;
 }
 
 /**

--- a/tests/test-mime.c
+++ b/tests/test-mime.c
@@ -162,6 +162,10 @@ static struct {
 	{ "A Group(Some people):Chris Jones <c@(Chris's host.)public.example>, joe@example.org, John <jdoe@one.test> (my dear friend); (the end of the group)", NULL,
 	  "A Group: Chris Jones <c@public.example>, joe@example.org, John <jdoe@one.test>;",
 	  "A Group: Chris Jones <c@public.example>, joe@example.org, John <jdoe@one.test>;" },
+	/* odd number of double quotes in rfc-2047 encoded display-name */
+	{ "=?UTF-8?Q?foo=20=22=20bar?= <test@mail.net>", "utf-8",
+	  "\"foo \\\" bar\" <test@mail.net>",
+	  "\"foo \\\" bar\" <test@mail.net>"},
 	/* The following tests cases are meant to test forgivingness
 	 * of the parser when it encounters unquoted specials in the
 	 * name component */


### PR DESCRIPTION
Prior to this change, when formatting address lists without RFC-2047 encoding, the display names are quoted if and only if they contain specials that are preceded by an even number of dquotes without checking wheter the "qstrings" are terminated. This means that the two address lists

    =?UTF-8?Q?=22=20=3Cfoo=40bar=2Ecom=3E=2C=20=22?= <test@mail.net>
    =?UTF-8?Q?=22=?= <foo@bar.com>, =?UTF-8?Q?=22?= <test@mail.net>

were identically formatted as `" <foo@bar.com>, " <test@mail.net>`.

With this change, display names are also quoted when they end in an unterminated quoted string. The second address list is now formatted as `"\"" <foo@bar.com>, "\"" <test@mail.net>`.