### PR TITLE
Fix buffer overrun

### DIFF
--- a/gmime/charset-map.c
+++ b/gmime/charset-map.c
@@ -91,7 +91,7 @@ static guint
 block_hash (gconstpointer v)
 {
 	const signed char *p = v;
-	guint32 h = *p++;
+	guint32 h = 0;
 	int i;
 	
 	for (i = 0; i < 256; i++)


### PR DESCRIPTION
This fixes a buffer overrun in the charset-map generator. Without this fix you get duplicate charmaps because the hash function reads garbage data and can't detect that 2 buffers are equal. This should reduce the amount of duplicate buffers to 0.