### PR TITLE
Support for the meson build system

### DIFF
--- a/config_meson.h.in
+++ b/config_meson.h.in
@@ -1,0 +1,172 @@
+/* Define if GMime should enable GpgME PGP and S/MIME support. */
+#mesondefine ENABLE_CRYPTO
+
+/* Define if GMime should enable warning output. */
+/* #undef ENABLE_WARNINGS */
+#mesondefine ENABLE_WARNINGS
+
+/* Define to the GMime version */
+#define GMIME_VERSION @GMIME_VERSION@
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#mesondefine HAVE_DLFCN_H
+
+/* Define to 1 if you have the `fsync` function. */
+#mesondefine HAVE_FSYNC
+
+/* Define to 1 if you have the `getaddrinfo' function. */
+#mesondefine HAVE_GETADDRINFO
+
+/* Define to 1 if you have the `getdomainname' function. */
+#mesondefine HAVE_GETDOMAINNAME
+
+/* Define to 1 if you have the `gethostname' function. */
+#mesondefine HAVE_GETHOSTNAME
+
+/* Define to 1 if you have the <getopt.h> header with the GNU `getopt_long`
+   function. */
+#mesondefine HAVE_GETOPT_H
+
+/* Define to 1 if you have the `getpagesize' function. */
+#mesondefine HAVE_GETPAGESIZE
+
+/* Define to 1 to use auto-detected iconv-friendly charset names. */
+#mesondefine HAVE_ICONV_DETECT_H
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#mesondefine HAVE_INTTYPES_H
+
+/* Define to 1 if you have a working `mmap' system call. */
+#mesondefine HAVE_MMAP
+
+/* Define to 1 if you have the `msync' function. */
+#mesondefine HAVE_MSYNC
+
+/* Define to 1 if you have the `munmap' function. */
+#mesondefine HAVE_MUNMAP
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#mesondefine HAVE_NETDB_H
+
+/* Define to 1 if you have the `poll' function. */
+#mesondefine HAVE_POLL
+
+/* Define to 1 if you have the <poll.h> header file. */
+#mesondefine HAVE_POLL_H
+
+/* Define to 1 if you have the `select' function. */
+#mesondefine HAVE_SELECT
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#mesondefine HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#mesondefine HAVE_STDIO_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#mesondefine HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#mesondefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#mesondefine HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#mesondefine HAVE_SYS_MMAN_H
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#mesondefine HAVE_SYS_PARAM_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#mesondefine HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#mesondefine HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <time.h> header file. */
+#mesondefine HAVE_TIME_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#mesondefine HAVE_UNISTD_H
+
+/* Define if struct utsname has a domainname member */
+#mesondefine HAVE_UTSNAME_DOMAINNAME
+
+/* Define to 1 if you have the <winsock2.h> header file. */
+#mesondefine HAVE_WINSOCK2_H
+
+/* Define to 1 if GNU libidn2 should be used. */
+#mesondefine LIBIDN
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+
+/* Define with a value if your <sys/param.h> does not define MAXHOSTNAMELEN */
+#mesondefine MAXHOSTNAMELEN
+/* #undef MAXHOSTNAMELEN */
+
+/* Define to 0 if your system does not have the O_LARGEFILE flag */
+/* #undef O_LARGEFILE */
+#mesondefine O_LARGEFILE
+
+/* Define to the address where bug reports for this package should be sent. */
+// #define PACKAGE_BUGREPORT "https://github.com/jstedfast/gmime/issues"
+
+/* Define to the full name of this package. */
+// #define PACKAGE_NAME "gmime"
+
+/* Define to the full name and version of this package. */
+// #define PACKAGE_STRING "gmime 3.2.13"
+
+/* Define to the one symbol short name of this package. */
+// #define PACKAGE_TARNAME "gmime"
+
+/* Define to the home page for this package. */
+// #define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+// #define PACKAGE_VERSION "3.2.13"
+
+/* The size of `off_t', as computed by sizeof. */
+// #define SIZEOF_OFF_T 8
+
+/* The size of `size_t', as computed by sizeof. */
+// #define SIZEOF_SIZE_T 8
+
+/* The size of `ssize_t', as computed by sizeof. */
+// #define SIZEOF_SSIZE_T 8
+
+/* The size of `time_t', as computed by sizeof. */
+// #define SIZEOF_TIME_T 8
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+// #define STDC_HEADERS 1
+
+/* Using GNU libiconv */
+/* #undef USE_LIBICONV_GNU */
+
+/* Using a native implementation of iconv in a separate library */
+/* #undef USE_LIBICONV_NATIVE */
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef mode_t */
+
+/* Define to `unsigned long int` if <poll.h> does not define. */
+/* #undef nfds_t */
+
+/* Define to `long int' if <sys/types.h> does not define. */
+/* #undef off_t */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef ssize_t */

--- a/gmime/gmime-version_meson.h.in
+++ b/gmime/gmime-version_meson.h.in
@@ -1,0 +1,45 @@
+#define GMIME_MAJOR_VERSION (@GMIME_MAJOR_VERSION@U)
+
+/**
+ * GMIME_MINOR_VERSION:
+ *
+ * GMime's minor version.
+ **/
+#define GMIME_MINOR_VERSION (@GMIME_MINOR_VERSION@U)
+
+/**
+ * GMIME_MICRO_VERSION:
+ *
+ * GMime's micro version.
+ **/
+#define GMIME_MICRO_VERSION (@GMIME_MICRO_VERSION@U)
+
+/**
+ * GMIME_BINARY_AGE:
+ *
+ * GMime's binary age.
+ **/
+#define GMIME_BINARY_AGE    (@GMIME_BINARY_AGE@U)
+
+/**
+ * GMIME_INTERFACE_AGE:
+ *
+ * GMime's interface age.
+ **/
+#define GMIME_INTERFACE_AGE (@GMIME_INTERFACE_AGE@U)
+
+
+/**
+ * GMIME_CHECK_VERSION:
+ * @major: Minimum major version
+ * @minor: Minimum minor version
+ * @micro: Minimum micro version
+ *
+ * Check whether a GMime version equal to or greater than
+ * @major.@minor.@micro is present.
+ **/
+#define	GMIME_CHECK_VERSION(major,minor,micro)	\
+    (GMIME_MAJOR_VERSION > (major) || \
+     (GMIME_MAJOR_VERSION == (major) && GMIME_MINOR_VERSION > (minor)) || \
+     (GMIME_MAJOR_VERSION == (major) && GMIME_MINOR_VERSION == (minor) && \
+      GMIME_MICRO_VERSION >= (micro)))

--- a/gmime/meson.build
+++ b/gmime/meson.build
@@ -1,0 +1,221 @@
+libgmime_src = files(
+  'gmime-application-pkcs7-mime.c',
+  'gmime-autocrypt.c',
+  'gmime.c',
+  'gmime-certificate.c',
+  'gmime-charset.c',
+  'gmime-common.c',
+  'gmime-content-type.c',
+  'gmime-crypto-context.c',
+  'gmime-data-wrapper.c',
+  'gmime-disposition.c',
+  'gmime-encodings.c',
+  'gmime-events.c',
+  'gmime-filter-basic.c',
+  'gmime-filter-best.c',
+  'gmime-filter.c',
+  'gmime-filter-charset.c',
+  'gmime-filter-checksum.c',
+  'gmime-filter-dos2unix.c',
+  'gmime-filter-enriched.c',
+  'gmime-filter-from.c',
+  'gmime-filter-gzip.c',
+  'gmime-filter-html.c',
+  'gmime-filter-openpgp.c',
+  'gmime-filter-smtp-data.c',
+  'gmime-filter-strip.c',
+  'gmime-filter-unix2dos.c',
+  'gmime-filter-windows.c',
+  'gmime-filter-yenc.c',
+  'gmime-format-options.c',
+  'gmime-gpg-context.c',
+  'gmime-gpgme-utils.c',
+  'gmime-header.c',
+  'gmime-iconv.c',
+  'gmime-iconv-utils.c',
+  'gmime-message.c',
+  'gmime-message-part.c',
+  'gmime-message-partial.c',
+  'gmime-multipart.c',
+  'gmime-multipart-encrypted.c',
+  'gmime-multipart-signed.c',
+  'gmime-object.c',
+  'gmime-param.c',
+  'gmime-parser.c',
+  'gmime-parser-options.c',
+  'gmime-parse-utils.c',
+  'gmime-part.c',
+  'gmime-part-iter.c',
+  'gmime-pkcs7-context.c',
+  'gmime-references.c',
+  'gmime-signature.c',
+  'gmime-stream-buffer.c',
+  'gmime-stream.c',
+  'gmime-stream-cat.c',
+  'gmime-stream-file.c',
+  'gmime-stream-filter.c',
+  'gmime-stream-fs.c',
+  'gmime-stream-gio.c',
+  'gmime-stream-mem.c',
+  'gmime-stream-mmap.c',
+  'gmime-stream-null.c',
+  'gmime-stream-pipe.c',
+  'gmime-text-part.c',
+  'gmime-utils.c',
+  'internet-address.c',
+)
+
+private = [
+  'gmime-charset-map-private.h',
+  'gmime-table-private.h',
+  'gmime-parse-utils.h',
+  'gmime-gpgme-utils.h',
+  'gmime-internal.h',
+  'gmime-common.h',
+  'gmime-events.h',
+]
+
+libgmime_headers = [
+  'gmime-application-pkcs7-mime.h',
+  'gmime-autocrypt.h',
+  'gmime-certificate.h',
+  'gmime-charset.h',
+  'gmime-content-type.h',
+  'gmime-crypto-context.h',
+  'gmime-data-wrapper.h',
+  'gmime-disposition.h',
+  'gmime-encodings.h',
+  'gmime-error.h',
+  'gmime-filter-basic.h',
+  'gmime-filter-best.h',
+  'gmime-filter-charset.h',
+  'gmime-filter-checksum.h',
+  'gmime-filter-dos2unix.h',
+  'gmime-filter-enriched.h',
+  'gmime-filter-from.h',
+  'gmime-filter-gzip.h',
+  'gmime-filter.h',
+  'gmime-filter-html.h',
+  'gmime-filter-openpgp.h',
+  'gmime-filter-smtp-data.h',
+  'gmime-filter-strip.h',
+  'gmime-filter-unix2dos.h',
+  'gmime-filter-windows.h',
+  'gmime-filter-yenc.h',
+  'gmime-format-options.h',
+  'gmime-gpg-context.h',
+  'gmime.h',
+  'gmime-header.h',
+  'gmime-iconv.h',
+  'gmime-iconv-utils.h',
+  'gmime-message.h',
+  'gmime-message-part.h',
+  'gmime-message-partial.h',
+  'gmime-multipart-encrypted.h',
+  'gmime-multipart.h',
+  'gmime-multipart-signed.h',
+  'gmime-object.h',
+  'gmime-param.h',
+  'gmime-parser.h',
+  'gmime-parser-options.h',
+  'gmime-part.h',
+  'gmime-part-iter.h',
+  'gmime-pkcs7-context.h',
+  'gmime-references.h',
+  'gmime-signature.h',
+  'gmime-stream-buffer.h',
+  'gmime-stream-cat.h',
+  'gmime-stream-file.h',
+  'gmime-stream-filter.h',
+  'gmime-stream-fs.h',
+  'gmime-stream-gio.h',
+  'gmime-stream.h',
+  'gmime-stream-mem.h',
+  'gmime-stream-mmap.h',
+  'gmime-stream-null.h',
+  'gmime-stream-pipe.h',
+  'gmime-text-part.h',
+  'gmime-utils.h',
+  'gmime-version.h',
+  'internet-address.h',
+]
+
+inc_conf = include_directories('..', '../util')
+
+version_data = configuration_data()
+version_data.set('GMIME_MAJOR_VERSION', GMIME_MAJOR_VERSION)
+version_data.set('GMIME_MINOR_VERSION', GMIME_MINOR_VERSION)
+version_data.set('GMIME_MICRO_VERSION', GMIME_MICRO_VERSION)
+version_data.set('GMIME_BINARY_AGE', GMIME_BINARY_AGE)
+version_data.set('GMIME_INTERFACE_AGE', GMIME_INTERFACE_AGE)
+configure_file(input: 'gmime-version_meson.h.in',
+  output: 'gmime-version.h',
+  configuration : version_data
+)
+
+gen_table = executable('gen-table', 'gen-table.c')
+charset_map = executable('charset-map', 'charset-map.c', dependencies : deps, 
+  include_directories: inc_conf)
+
+# For the future, we can generate the source code at runtime instead of having
+# it in the filesystem
+# table_h = custom_target('gen-table',
+#   capture: true,
+#   output : ['gmime-table-private.h'],
+#   command : [gen_table])
+# charset_h = custom_target('charset-map',
+#   capture: true,
+#   output : ['gmime-charset-map-private.h'],
+#   command : [charset_map])
+#
+# libgmime = library(gmime_package, libgmime_src + table_h + charset_h, dependencies : deps, 
+#   include_directories: inc_conf, link_with: libutil, install: true)
+
+libgmime = library(gmime_package, libgmime_src, dependencies : deps, 
+  include_directories: inc_conf, link_with: libutil, install: true)
+
+pkg = import('pkgconfig')
+
+pkg.generate(libgmime,
+  name: meson.project_name(),
+  filebase: gmime_package,
+  subdirs: gmime_package,
+  description: 'MIME parser and utility library',
+  requires: LIBS,
+  # libraries_private: EXTRA_LIBS,
+  )
+
+install_headers(libgmime_headers, subdir: gmime_package / 'gmime')
+
+gnome = import('gnome')
+
+src_doc = meson.project_source_root() / 'gmime'
+
+if get_option('introspection')
+  gir_args = [
+    '--accept-unprefixed',
+    ]
+
+  gmime_gir = gnome.generate_gir(
+    libgmime,
+    sources: libgmime_src + libgmime_headers,
+    export_packages: [gmime_package],
+    header: 'gmime/gmime.h',
+    namespace: 'GMime',
+    nsversion: '3.0',
+    symbol_prefix: ['g_mime', 'gmime'],
+    identifier_prefix : 'GMime',
+    includes: [ 'GObject-2.0', 'Gio-2.0'],
+    dependencies: deps,
+    extra_args: gir_args,
+    fatal_warnings: true,
+    install: true,
+  )
+endif
+
+if get_option('vala')
+  gnome.generate_vapi(gmime_package,
+    sources: gmime_gir[0],
+    packages: [ 'gio-2.0' ],
+    install: true)
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,137 @@
+project('GMime',
+	['c'],
+	license: 'GPLv2',
+    version: '3.2.13',
+    meson_version: '>=1.0.0',
+    default_options : [
+    ])
+
+gmime_version = meson.project_version()
+ver_arr = gmime_version.split('.')
+
+GMIME_MAJOR_VERSION=ver_arr[0].to_int()
+GMIME_MINOR_VERSION=ver_arr[1].to_int()
+GMIME_MICRO_VERSION=ver_arr[2].to_int()
+GMIME_BINARY_AGE= 100 * GMIME_MINOR_VERSION + GMIME_MICRO_VERSION
+GMIME_INTERFACE_AGE=0
+
+gmime_package = 'gmime-@0@.0'.format(GMIME_MAJOR_VERSION)
+
+add_global_arguments('-DHAVE_CONFIG_H=1', language : 'c')
+
+iconv = dependency('iconv', required : false, method: get_option('iconv'))
+libidn2 = dependency('libidn2', version: '>=2.0.0', required : false)
+gpgme = dependency('gpgme', version: '>=1.6.0', required: get_option('crypto'))
+glib =  dependency('glib-2.0', version: '>=2.68')
+gobject = dependency('gobject-2.0')
+deps = [
+  dependency('zlib', version: '>=1.2.5.2'),
+  glib,
+  gpgme,
+  gobject,
+  dependency('gio-2.0'),
+  libidn2,
+  iconv,
+]
+
+gmime_prefix = get_option('prefix')
+gmime_datadir = join_paths(gmime_prefix, get_option('datadir'))
+
+cc = meson.get_compiler('c')
+
+conf_data = configuration_data()
+conf_data.set_quoted('GMIME_VERSION', meson.project_version())
+
+LIBS = ['glib-2.0', 'gio-2.0', 'gobject-2.0' ]
+EXTRA_LIBS = ['zlib']
+
+if cc.has_header('getopt.h')
+  if cc.has_function('getopt_long')
+    conf_data.set('HAVE_GETOPT_H', 1)
+  endif
+endif
+
+if gpgme.found()
+  conf_data.set('ENABLE_CRYPTO', 1)
+  EXTRA_LIBS += 'gpgme'
+  EXTRA_LIBS += 'gpg-error'
+endif
+
+if libidn2.found()
+  conf_data.set('LIBIDN', 1)
+  EXTRA_LIBS += 'libidn2'
+endif
+
+if iconv.found()
+  conf_data.set('HAVE_ICONV_DETECT_H', 1)
+  # EXTRA_LIBS += 'iconv'
+endif
+
+foreach hd : [
+    { 'm': 'HAVE_DLFCN_H',            'v': 'dlfcn.h', },
+    { 'm': 'HAVE_INTTYPES_H',         'v': 'inttypes.h', },
+    { 'm': 'HAVE_NETDB_H',            'v': 'netdb.h', },
+    { 'm': 'HAVE_STDINT_H',           'v': 'stdint.h', },
+    { 'm': 'HAVE_WINDOWS_H',          'v': 'windows.h'},
+    { 'm': 'HAVE_SYS_MMAN_H',         'v': 'sys/mman.h', },
+    { 'm': 'HAVE_SYS_PARAM_H',        'v': 'sys/param.h', },
+  ]
+  if cc.has_header(hd['v'])
+    conf_data.set10(hd['m'], true)
+  endif
+endforeach
+
+uts_prefix = '''
+#define _GNU_SOURCE
+#include <sys/utsname.h>
+'''
+
+if cc.has_member('struct utsname', 'domainname', prefix : uts_prefix)
+  conf_data.set10('HAVE_UTSNAME_DOMAINNAME', true)
+endif
+
+# Don't do this, meson does it automatically if needed
+# if cc.has_header_symbol('fcntl.h', 'O_LARGEFILE')
+#   conf_data.set10('O_LARGEFILE', true)
+# endif
+
+foreach fn : [
+    { 'm': 'HAVE_FSYNC',                    'v': 'fsync', },
+    { 'm': 'HAVE_GETADDRINFO',              'v': 'getaddrinfo', },
+    { 'm': 'HAVE_GETDOMAINNAME',            'v': 'getdomainname', },
+    { 'm': 'HAVE_GETHOSTNAME',              'v': 'gethostname', },
+    { 'm': 'HAVE_GETPAGESIZE',              'v': 'getpagesize', },
+    { 'm': 'HAVE_MMAP',                     'v': 'mmap', },
+    { 'm': 'HAVE_MSYNC',                    'v': 'msync', },
+    { 'm': 'HAVE_MUNMAP',                   'v': 'munmap', },
+    { 'm': 'HAVE_POLL',                     'v': 'poll', },
+    { 'm': 'HAVE_SELECT',                   'v': 'select', },
+  ]
+  if cc.has_function(fn['v'])
+    conf_data.set(fn['m'], 1)
+  endif
+endforeach
+
+configure_file(input: 'config_meson.h.in',
+  output: 'config.h',
+  configuration : conf_data
+)
+
+subdir('util')
+subdir('gmime')
+# if get_option('gtk_doc')
+  # subdir('docs/reference_gi')
+# endif
+subdir('tests')
+
+summary({'Install Prefix': get_option('prefix'),
+        'Compiler': cc.get_id(),
+        'Documentation': get_option('gtk_doc'),
+        'Profiling enabled': false, #TODO
+        'Coverage enabled': false, #TODO
+        'PGP/MIME support': get_option('crypto'),
+        'S/MIME support': get_option('crypto'),
+        'libidn2 support': libidn2.found(),
+        'GObject introspection': get_option('introspection'),
+        'Vala bindings': get_option('vala'),
+        }, section: 'Configuration')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+option('gtk_doc', type : 'boolean', value : false)
+# option('gtk_doc-html', type : 'boolean', value : true)
+# option('gtk_doc-pdf', type : 'boolean', value : false)
+
+option('iconv', type : 'combo', choices : ['auto', 'builtin', 'system'], value : 'auto')
+option('crypto', type : 'feature', value : 'enabled')
+option('introspection', type : 'boolean', value : true)
+option('vala', type : 'boolean', value : true)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,56 @@
+automated_tests = [
+  {'name': 'cat'},
+  {'name': 'encodings' },
+  {'name': 'filters' },
+  {'name': 'headers' },
+  {'name': 'iconv' },
+  {'name': 'mbox' },
+  {'name': 'mime' },
+  {'name': 'mime-part' },
+  {'name': 'partial' },
+  {'name': 'streams' },
+]
+
+manual_tests = [
+  {'name': 'best'},
+  {'name': 'parser'},
+  {'name': 'html'}
+]
+
+test_deps = deps
+
+if gpgme.found()
+  test_deps += dependency('gpg-error')
+  automated_tests += [
+    {'name': 'pgp', 'parallel': false}, 
+    {'name': 'pgpmime', 'parallel': false},
+    {'name': 'autocrypt', 'parallel': false}
+  ]
+  manual_tests += [
+    {'name': 'pkcs7', 'parallel': false},
+    {'name': 'smime', 'parallel': false}
+  ]
+endif
+
+# automated_tests += manual_tests
+
+gmime_include = include_directories('..', '../gmime/', '../util')
+fs = import('fs')
+
+test_dir = meson.project_source_root() / 'tests'
+
+foreach at : automated_tests
+  name = at.get('name')
+  testdatadir = at.get('testdir', 'data' / name)
+  parallel = at.get('parallel', true)
+  args = at.get('args', ['-v'])
+
+  exec = executable(name, 'test-@0@.c'.format(name), 'testsuite.c', 
+    dependencies : test_deps, include_directories: gmime_include, 
+    link_with: [libgmime, libutil])
+
+  if fs.is_dir(testdatadir)
+    args += testdatadir
+  endif
+  test(name, exec, args: args, is_parallel: parallel, workdir : test_dir)
+endforeach

--- a/util/meson.build
+++ b/util/meson.build
@@ -1,0 +1,8 @@
+util_src = files(
+  'gtrie.c',
+  'packed.c',
+  'url-scanner.c',
+)
+
+inc_conf = include_directories('..')
+libutil = static_library('util', util_src, dependencies : deps, include_directories: inc_conf)


### PR DESCRIPTION
This add support for the meson build system which supports multiple operating systems among things out of the box. This requires https://github.com/jstedfast/gmime/pull/141 to be merged, because gnome.generate_gir() treats warnings as errors.