### PR TITLE
build: avoid useless configure-time checks

### DIFF
--- a/build/vs2008/config-win32.h.in
+++ b/build/vs2008/config-win32.h.in
@@ -153,15 +153,6 @@
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "@GMIME_VERSION@"
 
-/* The size of `off_t', as computed by sizeof. */
-#define SIZEOF_OFF_T 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `ssize_t', as computed by sizeof. */
-#define SIZEOF_SSIZE_T 4
-
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 

--- a/build/vs2010/config-win32.h.in
+++ b/build/vs2010/config-win32.h.in
@@ -153,15 +153,6 @@
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "@GMIME_VERSION@"
 
-/* The size of `off_t', as computed by sizeof. */
-#define SIZEOF_OFF_T 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `ssize_t', as computed by sizeof. */
-#define SIZEOF_SSIZE_T 4
-
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -440,15 +440,6 @@ else
 fi
 AM_CONDITIONAL(ENABLE_LARGEFILE, test "x$enable_largefile" = "xyes")
 
-dnl Check type sizes
-CFLAGS_save="$CFLAGS"
-CFLAGS="$CFLAGS $LFS_CFLAGS"
-AC_CHECK_SIZEOF(ssize_t)
-AC_CHECK_SIZEOF(size_t)
-AC_CHECK_SIZEOF(off_t)
-AC_CHECK_SIZEOF(time_t)
-CFLAGS="$CFLAGS_save"
-
 dnl Check for some network functions
 AC_CHECK_FUNCS(gethostname getdomainname getaddrinfo)
 


### PR DESCRIPTION
Checking for the sizeof various types and defining preprocessor macros for them, is pointless, since the *only* effect these had was defining said macros... and the code never did anything with them.

This speeds up running configure and is less confusing to readers. It's also less confusing to porters, as evidenced by the VS projects which contain out of date copies of the config.h files that are missing some of these unused checks.