### PR TITLE
Fix some warnings from g_string_free.

### DIFF
--- a/gmime/gmime-parse-utils.c
+++ b/gmime/gmime-parse-utils.c
@@ -493,8 +493,7 @@ g_mime_decode_addrspec (const char **in)
 		goto exception;
 	}
 	
-	str = addrspec->str;
-	g_string_free (addrspec, FALSE);
+	str = g_string_free (addrspec, FALSE);
 	
 	*in = inptr;
 	

--- a/gmime/gmime-utils.c
+++ b/gmime/gmime-utils.c
@@ -985,8 +985,7 @@ g_mime_utils_quote_string (const char *str)
 	if (quote)
 		g_string_append_c (out, '"');
 	
-	qstring = out->str;
-	g_string_free (out, FALSE);
+	qstring = g_string_free (out, FALSE);
 	
 	return qstring;
 }
@@ -2471,8 +2470,7 @@ rfc2047_encode (GMimeFormatOptions *options, const char *in, gushort safemask, c
 	
 	rfc822_word_free (prev);
 	
-	outstr = out->str;
-	g_string_free (out, FALSE);
+	outstr = g_string_free (out, FALSE);
 	
 	return outstr;
 }

--- a/gmime/internet-address.c
+++ b/gmime/internet-address.c
@@ -279,9 +279,8 @@ internet_address_to_string (InternetAddress *ia, GMimeFormatOptions *options, gb
 	
 	string = g_string_new ("");
 	INTERNET_ADDRESS_GET_CLASS (ia)->to_string (ia, options, flags, &linelen, string);
-	str = string->str;
 	
-	g_string_free (string, FALSE);
+	str = g_string_free (string, FALSE);
 	
 	return str;
 }


### PR DESCRIPTION
Using the latest version of glib, glib has started to report a warning if the return value of g_string_free isn't used, when free_segment is set FALSE. It also makes the code tidier.