### PR TITLE
Adding a GNotifyDestroy to parser options callback.

### DIFF
--- a/examples/msgcheck.c
+++ b/examples/msgcheck.c
@@ -110,7 +110,7 @@ check_msg_file (const gchar *filename)
 		parser = g_mime_parser_new ();
 		g_mime_parser_init_with_stream (parser, stream);
 		options = g_mime_parser_options_new ();
-		g_mime_parser_options_set_warning_callback (options, parser_issue, NULL);
+		g_mime_parser_options_set_warning_callback (options, parser_issue, NULL, NULL);
 		message = g_mime_parser_construct_message (parser, options);
 		g_mime_parser_options_free (options);
 		g_object_unref (parser);

--- a/gmime/gmime-parser-options.h
+++ b/gmime/gmime-parser-options.h
@@ -128,8 +128,8 @@ const char **g_mime_parser_options_get_fallback_charsets (GMimeParserOptions *op
 void g_mime_parser_options_set_fallback_charsets (GMimeParserOptions *options, const char **charsets);
 
 GMimeParserWarningFunc g_mime_parser_options_get_warning_callback (GMimeParserOptions *options);
-void g_mime_parser_options_set_warning_callback (GMimeParserOptions *options, GMimeParserWarningFunc warning_cb,
-						 gpointer user_data);
+void g_mime_parser_options_set_warning_callback (GMimeParserOptions *options, 
+		GMimeParserWarningFunc warning_cb, gpointer user_data, GDestroyNotify notify);
 
 G_END_DECLS
 


### PR DESCRIPTION
This makes g_mime_parser_options_set_warning_callback introspectable. For C code currently using this function, adding NULL as the last parameter will enable same semantics as the old code.