### PR TITLE
Fixes a memory bug with parser option

### DIFF
--- a/gmime/gmime-parser-options.c
+++ b/gmime/gmime-parser-options.c
@@ -70,11 +70,11 @@ g_mime_parser_options_shutdown (void)
 	if (default_options == NULL)
 		return;
 	
-	g_strfreev (default_options->charsets);
-	g_slice_free (GMimeParserOptions, default_options);
-	if (default_options->warning_user_data && default_options->notify) {
+	if (default_options->notify) {
 		default_options->notify(default_options->warning_user_data);
 	}
+	g_strfreev (default_options->charsets);
+	g_slice_free (GMimeParserOptions, default_options);
 	default_options = NULL;
 }
 
@@ -174,6 +174,8 @@ g_mime_parser_options_clone (GMimeParserOptions *options)
 	
 	clone->warning_cb = options->warning_cb;
 	clone->warning_user_data = options->warning_user_data;
+	// We transfer the pointer not ownership. So we don't copy the notify
+	clone->notify = NULL;
 
 	return clone;
 }
@@ -191,11 +193,11 @@ g_mime_parser_options_free (GMimeParserOptions *options)
 	g_return_if_fail (options != NULL);
 	
 	if (options != default_options) {
-		g_strfreev (options->charsets);
-		g_slice_free (GMimeParserOptions, options);
-		if (options->warning_user_data && options->notify) {
+		if (options->notify) {
 			options->notify(options->warning_user_data);
 		}
+		g_strfreev (options->charsets);
+		g_slice_free (GMimeParserOptions, options);
 	}
 }
 
@@ -457,7 +459,7 @@ g_mime_parser_options_set_warning_callback (GMimeParserOptions *options, GMimePa
 {
 	g_return_if_fail (options != NULL);
 
-	if (options->warning_user_data && options->notify) {
+	if (options->notify) {
 		options->notify(options->warning_user_data);
 	}
 	


### PR DESCRIPTION
In the last PR for parser options, there is a use after free. Also GDestroyNotify is safe on null.