### PR TITLE
Make gir follow the spec.

### DIFF
--- a/gmime/gmime-filter-charset.h
+++ b/gmime/gmime-filter-charset.h
@@ -42,7 +42,7 @@ typedef struct _GMimeFilterCharsetClass GMimeFilterCharsetClass;
  * @parent_object: parent #GMimeFilter
  * @from_charset: charset that the filter is converting from
  * @to_charset: charset the filter is converting to
- * @cd: charset conversion state
+ * @cd: (type gpointer): charset conversion state
  *
  * A filter to convert between charsets.
  **/

--- a/gmime/gmime-iconv-utils.c
+++ b/gmime/gmime-iconv-utils.c
@@ -49,7 +49,7 @@
 
 /**
  * g_mime_iconv_strndup: (skip)
- * @cd: conversion descriptor
+ * @cd: (type gpointer): conversion descriptor
  * @str: string in source charset
  * @n: number of bytes to convert
  *
@@ -152,7 +152,7 @@ g_mime_iconv_strndup (iconv_t cd, const char *str, size_t n)
 
 /**
  * g_mime_iconv_strdup: (skip)
- * @cd: conversion descriptor
+ * @cd: (type gpointer): conversion descriptor
  * @str: string in source charset
  *
  * Allocates a new string buffer containing @str converted to the

--- a/gmime/gmime-iconv.c
+++ b/gmime/gmime-iconv.c
@@ -54,7 +54,7 @@
  *
  * See the manual page for iconv_open(3) for further details.
  *
- * Returns: a new conversion descriptor for use with g_mime_iconv() on
+ * Returns: (type gpointer): a new conversion descriptor for use with g_mime_iconv() on
  * success or (iconv_t) %-1 on fail as well as setting an appropriate
  * errno value.
  **/
@@ -78,7 +78,7 @@ g_mime_iconv_open (const char *to, const char *from)
 
 /**
  * g_mime_iconv_close: (skip)
- * @cd: iconv conversion descriptor
+ * @cd: (type gpointer): iconv conversion descriptor
  *
  * Closes the iconv descriptor @cd.
  *


### PR DESCRIPTION
Without this change, the generated gir doesn't follow the spec and some tools fail to parse the gir. This isn't a problem overall because these are skipped because they are marked as not introspectable. But for some languages (rust), the introspectable tag is more of a suggestion and (skip)-ed objects and functions are still parsed. Not having a name for the type creates an error which in part breaks the gir generation tool.