### PR TITLE
g_mime_object_get_header can return null in the gir

### DIFF
--- a/gmime/gmime-object.c
+++ b/gmime/gmime-object.c
@@ -900,7 +900,7 @@ g_mime_object_set_header (GMimeObject *object, const char *header, const char *v
  *
  * Gets the value of the first header with the specified name.
  *
- * Returns: the value of the requested header if it
+ * Returns: (nullable): the value of the requested header if it
  * exists or %NULL otherwise.
  **/
 const char *


### PR DESCRIPTION
g_mime_object_get_header doesn't return a nullable which both the code and the comment says it can do.