### PR TITLE
Fix compiler error with 32 bit gcc 14 in Windows

### DIFF
--- a/gmime/gmime-gpgme-utils.c
+++ b/gmime/gmime-gpgme-utils.c
@@ -32,28 +32,28 @@
 
 #define _(x) x
 
-static ssize_t
+static gpgme_ssize_t
 g_mime_gpgme_stream_read (void *stream, void *buffer, size_t size)
 {
 	return g_mime_stream_read ((GMimeStream *) stream, (char *) buffer, size);
 }
 
-static ssize_t
+static gpgme_ssize_t
 g_mime_gpgme_stream_write (void *stream, const void *buffer, size_t size)
 {
 	return g_mime_stream_write ((GMimeStream *) stream, (const char *) buffer, size);
 }
 
-static off_t
-g_mime_gpgme_stream_seek (void *stream, off_t offset, int whence)
+static gpgme_off_t
+g_mime_gpgme_stream_seek (void *stream, gpgme_off_t offset, int whence)
 {
 	switch (whence) {
 	case SEEK_SET:
-		return (off_t) g_mime_stream_seek ((GMimeStream *) stream, (gint64) offset, GMIME_STREAM_SEEK_SET);
+		return (gpgme_off_t) g_mime_stream_seek ((GMimeStream *) stream, (gint64) offset, GMIME_STREAM_SEEK_SET);
 	case SEEK_CUR:
-		return (off_t) g_mime_stream_seek ((GMimeStream *) stream, (gint64) offset, GMIME_STREAM_SEEK_CUR);
+		return (gpgme_off_t) g_mime_stream_seek ((GMimeStream *) stream, (gint64) offset, GMIME_STREAM_SEEK_CUR);
 	case SEEK_END:
-		return (off_t) g_mime_stream_seek ((GMimeStream *) stream, (gint64) offset, GMIME_STREAM_SEEK_END);
+		return (gpgme_off_t) g_mime_stream_seek ((GMimeStream *) stream, (gint64) offset, GMIME_STREAM_SEEK_END);
 	default:
 		return -1;
 	}


### PR DESCRIPTION

    This fixes the following compiler error.
    
    ../../gmime/gmime-gpgme-utils.c:69:9: error: initialization of
    'gpgme_ssize_t (*)(void *, void *, size_t)' {aka 'long int (*)(void *, void *, unsigned int)'}
    from incompatible pointer type
    'ssize_t (*)(void *, void *, size_t)' {aka 'int (*)(void *, void *, unsigned int)'}
    [-Wincompatible-pointer-types]
       69 |         g_mime_gpgme_stream_read,
          |         ^~~~~~~~~~~~~~~~~~~~~~~~
