### PR TITLE
Tune up fix for autoconf 2.72

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -461,7 +461,7 @@ if test "x$enable_largefile" != "xno"; then
         enable_largefile="yes"
     fi
     
-    if test "x$ac_cv_sys_file_offset_bits" != "x"; then
+    if test "x$ac_cv_sys_file_offset_bits" != "x" && test "$ac_cv_sys_file_offset_bits" != "xno"; then
         LFS_CFLAGS="$LFS_CFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
         enable_largefile="yes"
     fi


### PR DESCRIPTION
In #158, the build for gmime was corrected for autoconf version 2.72, which treats ac_cv_sys_file_offset_bits differently. (see de4f1b044141df3ef0b1fc20be422dc667443484)

This fix should make gmime keep building on systems that use older version of autoconf, not just 2.72 or later.