### PR TITLE
Add Julia bindings for gmime

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ The current list of known bindings are:
 |Go         |https://github.com/sendgrid/go-gmime    |
 |Perl       |http://search.cpan.org/dist/MIME-Fast   |
 |C#         |https://github.com/jstedfast/MimeKit    |
-
+|Julia      |https://github.com/bhftbootcamp/GMime.jl|
 
 ## Reporting Bugs
 


### PR DESCRIPTION
Hi, we have created a Julia binding for gmime, and it is now available in the official Julia registries under the name [GMime](https://github.com/bhftbootcamp/GMime.jl) (will be [registered](https://github.com/JuliaRegistries/General/pull/116782) in 72 hours). Thanks for creating such a great library!