### PR TITLE
Update autogen.sh to support libtool versions newer than 2.4

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -28,7 +28,7 @@ have_libtool=false
 if ${LIBTOOLIZE} --version < /dev/null > /dev/null 2>&1 ; then
 	libtool_version=`${LIBTOOLIZE} --version | sed '/^$/d;s/([^)]*)//g;s/^[^0-9]*//;s/[- ].*//g;q'`
 	case $libtool_version in
-	    1.4*|1.5*|2.2*|2.4*)
+	    1.4*|1.5*|2.2*|2.4*|2.5*)
 		have_libtool=true
 		;;
 	esac


### PR DESCRIPTION
The current libtool version is 2.5.3, and autogen.sh does not look for it:
```
./autogen.sh
+ test -n
+ dirname ./autogen.sh
+ srcdir=.
+ test -n .
+ pwd
+ ORIGDIR=/usr/local/tmp/crew/gmime.20241111150237.dir
+ cd .
+ PROJECT=GMime
+ TEST_TYPE=-f
+ FILE=configure.ac
+ DIE=0
+ command -v glibtoolize
+ LIBTOOLIZE=
+ test -z
+ command -v libtoolize
+ LIBTOOLIZE=/usr/local/bin/libtoolize
+ test -z /usr/local/bin/libtoolize
+ have_libtool=false
+ /usr/local/bin/libtoolize --version
+ /usr/local/bin/libtoolize --version
+ sed /^$/d;s/([^)]*)//g;s/^[^0-9]*//;s/[- ].*//g;q
+ libtool_version=2.5.3
+ false
+ echo                                                                                                                                                                                                                                          + echo You must have libtool >= 1.4 installed to compile GMime.
You must have libtool >= 1.4 installed to compile GMime.
+ echo Install the appropriate package for your distribution,
Install the appropriate package for your distribution,
+ echo or get the source tarball at http://ftp.gnu.org/gnu/libtool/
or get the source tarball at http://ftp.gnu.org/gnu/libtool/
+ DIE=1
+ automake-1.9 --version
+ automake-1.10 --version
+ automake-1.11 --version
+ automake-1.12 --version
+ automake-1.13 --version
+ automake-1.14 --version
+ automake-1.15 --version
+ automake-1.16 --version
+ AUTOMAKE=automake-1.16
+ ACLOCAL=aclocal-1.16
+ break
+ test -z automake-1.16
+ test 1 -eq 1
+ exit 1
```